### PR TITLE
Move work items top and bottom for order of execution  (#558)

### DIFF
--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -28,10 +28,10 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="wi_filter_dropdown">
         <li>
-          <a role="menuitem" tabindex="-1">Move to Top</a>
+          <a role="menuitem" tabindex="-1" (click)='onMoveToTop(workItemToMove)' > Move to Top </a>
         </li>
         <li>
-          <a role="menuitem" tabindex="-1">Move to Bottom</a>
+          <a role="menuitem" tabindex="-1" (click)='onMoveToBottom(workItemToMove)' > Move to Bottom </a>
         </li>
         <li role="presentation" class="divider"></li>
         <li>

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -63,7 +63,7 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   loggedIn: Boolean = false;
   showWorkItemDetails: boolean = false;
   panelState: String = 'out';
-  contentItemHeight: number = 65;
+  contentItemHeight: number = 67;
   pageSize: number = 20;
   filters: any[] = [];
   allUsers: User[] = [] as User[];
@@ -209,12 +209,18 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
 
   onMoveToTop(entryComponent: WorkItemListEntryComponent): void {
     this.workItemDetail = entryComponent.getWorkItem();
-    this.workItemService.moveItem(this.workItemDetail, 'top');
+    this.workItemService.moveItem(this.workItemDetail, 'top')
+    .then(() => {
+      this.listContainer.nativeElement.scrollTop = 0;
+    });
   }
 
   onMoveToBottom(entryComponent: WorkItemListEntryComponent): void {
     this.workItemDetail = entryComponent.getWorkItem();
-    this.workItemService.moveItem(this.workItemDetail, 'bottom');
+    this.workItemService.moveItem(this.workItemDetail, 'bottom')
+    .then(() => {
+      this.listContainer.nativeElement.scrollTop = this.workItems.length * this.contentItemHeight;
+    });
   }
 
   onMoveUp(): void {

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -435,16 +435,24 @@ export class WorkItemService {
    * ToDo: Integrate backend when available, also move by one
    * place should be implemented
    */
-  moveItem(wi: WorkItem, dir: String): void {
+  moveItem(wi: WorkItem, dir: String): Promise<any> {
     let index = this.workItems.findIndex(x => x.id == wi.id);
     wi.attributes.nextitem = '';
     wi.attributes.previousitem = '';
     switch (dir){
       case 'top':
-        //this.workItems.splice(0, 0, wi);
+        //move the item as the first item
+        this.workItems.splice(0, 0, wi);
+        //remove the duplicate element
+        this.workItems.splice( index + 1, 1);
+        wi.attributes.nextitem = parseInt(this.workItems[1].id);
         break;
       case 'bottom':
-        //this.workItems.splice(this.workItems.length, 0, wi);
+        //move the item as the last of the loaded list
+        this.workItems.splice((this.workItems.length), 0, wi);
+        //remove the duplicate element
+        this.workItems.splice( index, 1);
+        wi.attributes.previousitem = parseInt(this.workItems[this.workItems.length-2].id);
         break;
       case 'up':
         if (index > 0) { //no moving of element if it is the first element
@@ -480,6 +488,7 @@ export class WorkItemService {
     //console.log(wi.attributes.previousitem, ':' , wi.attributes.nextitem);
     //build the map to reset the indices
     this.buildWorkItemIdIndexMap();
+    return Promise.resolve();
     /*
     return this.http
       .patch(this.reorderUrl, JSON.stringify({data: wi}), { headers: this.headers })


### PR DESCRIPTION
This PR will add the UI behaviour only, for moving a work item to either the top or bottom of the visible screen.
UI Task - #558
Note: Current implementation of Move to Bottom will take the user to the end of the loaded list.