### PR TITLE
Move a work item up and down for order of execution (#557)

### DIFF
--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -1,10 +1,14 @@
-<div *ngIf="showDialog">	
+<div *ngIf="showDialog">
 	<alm-dialog
 		(pfDialogClick)="onButtonClick($event)"
-		[dialog]='dialog'	
+		[dialog]='dialog'
 	></alm-dialog>
 </div>
 <div class="list-group-item" (click)="onSelect($event)" [class.selected]="isSelected()">
+	<!--checkbox to select a WI and move it-->
+	<div class="row-cbh" title="Select the checkbox to move the item.">
+		<input type="checkbox" [checked]="checkedWI" (click)="toggleEntry($event)" />
+	</div>
 	<!-- info area -->
 	<div class="list-view-pf-main-info" (click)="onDetail($event)">
 		<div class="list-view-pf-left type workItemList_workItemType">
@@ -25,7 +29,7 @@
 	</div>
 
   <div class="user-avatar">
-      <img  
+      <img
         *ngFor="let wItem of workItem.relationalData.assignees"
         tooltipPlacement="bottom"
         tooltip="{{wItem.attributes.fullName}}"
@@ -43,9 +47,9 @@
 			<ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
 				<li><a class="workItemList_MoveTop" (click)="onMoveToTop($event)">Move to Top</a></li>
 				<li><a class="workItemList_MoveBottom" (click)="onMoveToBottom($event)">Move to Bottom</a></li>
-				<li role="presentation" class="divider"></li>				
+				<li role="presentation" class="divider"></li>
 				<li><a [routerLink]="['/work-item-list/detail/' + workItem.id]" class="workItemList_Open">Open</a></li>
-				<li><a class="workItemList_Delete" (click)="confirmDelete($event)">Delete</a></li>				
+				<li><a class="workItemList_Delete" (click)="confirmDelete($event)">Delete</a></li>
 				<li><a class="workItemList_Backlog" (click)="onMoveToBacklog($event)">Move to Backlog</a></li>
 			</ul>
 		</div>

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.scss
@@ -5,6 +5,12 @@
   cursor: pointer;
   font-size: rem(12);
   align-items: center;
+  .row-cbh {
+    margin-right: em(10);
+    margin-left: em(5);
+    padding-right: em(10);
+    border-right: 1px solid $color-pf-black-500;
+  }
   .workItemList_workItemType {
     width: em(120);
     float: left;

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
@@ -37,11 +37,13 @@ import { WorkItemService } from '../../work-item.service';
 export class WorkItemListEntryComponent implements OnInit {
 
   @Input() workItem: WorkItem;
+  @Output() toggleEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() selectEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() detailEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() moveTopEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() moveBottomEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
 
+  checkedWI: boolean = false;
   selected: boolean = false;
   dialog: Dialog;
   showDialog = false;
@@ -74,6 +76,18 @@ export class WorkItemListEntryComponent implements OnInit {
     return this.selected;
   }
 
+  isChecked(): boolean {
+    return this.checkedWI;
+  }
+
+  check(): void {
+    this.checkedWI = true;
+  }
+
+  uncheck(): void {
+    this.checkedWI = false;
+  }
+
   // helpers
 
   confirmDelete(event: MouseEvent) {
@@ -90,7 +104,7 @@ export class WorkItemListEntryComponent implements OnInit {
   }
 
   onButtonClick(val: number) {
-    // callback from the confirm delete dialog 
+    // callback from the confirm delete dialog
     if (val == 1) {
       this.onDelete(null);
     }
@@ -99,6 +113,11 @@ export class WorkItemListEntryComponent implements OnInit {
 
   selectEntry(): void {
     this.selectEvent.emit(this);
+  }
+
+  toggleEntry(event: MouseEvent): void {
+    event.stopPropagation();
+    this.toggleEvent.emit(this);
   }
 
   // event handlers
@@ -120,14 +139,14 @@ export class WorkItemListEntryComponent implements OnInit {
     this.detailEvent.emit(this);
     this.router.navigate(['/work-item-list/detail/' + this.workItem.id]);
   }
-  
+
   onMoveToTop(event: MouseEvent): void {
-    event.stopPropagation();    
+    event.stopPropagation();
     this.moveTopEvent.emit(this);
   }
 
   onMoveToBottom(event: MouseEvent): void {
-    event.stopPropagation();    
+    event.stopPropagation();
     this.moveBottomEvent.emit(this);
   }
 

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -20,6 +20,29 @@
 <div class="detail-list-container" [class.containerPadd-nologin] = "!loggedIn" >
   <div class="list-action">
     <h4 class="list-type">Backlog</h4>
+    <!--Move a work item up / down -->
+    <div *ngIf="workItemToMove" class="dropdown move-dropdown" dropdown>
+      <button class="btn btn-default dropdown-toggle" type="button" id="wi_filter_dropdown" data-toggle="dropdown" dropdown-open>
+        Move
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="wi_filter_dropdown">
+        <li>
+          <a role="menuitem" tabindex="-1">Move to Top</a>
+        </li>
+        <li>
+          <a role="menuitem" tabindex="-1">Move to Bottom</a>
+        </li>
+        <li role="presentation" class="divider"></li>
+        <li>
+          <a role="menuitem" tabindex="-1" (click)='onMoveUp()'>Move Up</a>
+        </li>
+        <li>
+          <a role="menuitem" tabindex="-1" (click)='onMoveDown()'>Move Down</a>
+        </li>
+      </ul>
+    </div>
+    <!--Filter-->
     <div class="dropdown filter-dropdown" dropdown>
       <button class="btn btn-default dropdown-toggle" type="button" id="wi_filter_dropdown" data-toggle="dropdown" dropdown-open>
         Filter Method
@@ -69,6 +92,7 @@
           id="{{'workItemList_OuterWrap_'+counter}}"
           class="work-item-list-entry"
           [workItem]="workItem"
+          (toggleEvent)="onToggle($event)"
           (selectEvent)="onSelect($event)"
           (detailEvent)="onDetail($event)"
           (moveTopEvent)="onMoveToTop($event)"

--- a/src/app/work-item/work-item-list/work-item-list.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list.component.scss
@@ -87,6 +87,13 @@
       border-width: 1px 0;
       padding: 1px 10px;
     }
+    .move-dropdown {
+      position: absolute;
+      left: em(100);
+      a {
+        cursor: pointer;
+      }
+    }
     .filter-dropdown {
       margin-right: em(10);
     }

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -56,6 +56,7 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   workItems: WorkItem[];
   workItemTypes: WorkItemType[];
   selectedWorkItemEntryComponent: WorkItemListEntryComponent;
+  workItemToMove: WorkItemListEntryComponent;
   workItemDetail: WorkItem;
   addingWorkItem = false;
   showOverlay : Boolean ;
@@ -175,12 +176,26 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   }
 
   // event handlers
+  onToggle(entryComponent: WorkItemListEntryComponent): void {
+    // This condition is to select a single work item for movement
+    // deselect the previous checked work item
+    if (this.workItemToMove) {
+      this.workItemToMove.uncheck();
+    }
+    if (this.workItemToMove == entryComponent) {
+      this.workItemToMove = null;
+    } else {
+      entryComponent.check();
+      this.workItemToMove = entryComponent;
+    }
+  }
 
   onSelect(entryComponent: WorkItemListEntryComponent): void {
     let workItem: WorkItem = entryComponent.getWorkItem();
     // de-select prior selected element (if any)
-    if (this.selectedWorkItemEntryComponent && this.selectedWorkItemEntryComponent != entryComponent)
+    if (this.selectedWorkItemEntryComponent && this.selectedWorkItemEntryComponent != entryComponent) {
       this.selectedWorkItemEntryComponent.deselect();
+    }
     // select new component
     entryComponent.select();
     this.selectedWorkItemEntryComponent = entryComponent;
@@ -200,6 +215,16 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   onMoveToBottom(entryComponent: WorkItemListEntryComponent): void {
     this.workItemDetail = entryComponent.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'bottom');
+  }
+
+  onMoveUp(): void {
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'up');
+  }
+
+  onMoveDown(): void {
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'down');
   }
 
   // Event listener for URL change


### PR DESCRIPTION
This PR will add the UI behaviour only, for moving a work item up or down.
UI Task - #557.

Note: There are two experiences - selecting a work item and checking a work item to move it.
1. Selecting a work item will highlight the work item and open the detailed view.
2. Selecting the checkbox will display the move options menu
3. A work item whose checkbox is selected can be moved up or down
4. If a work item is selected with it's detailed view open, select the checkbox on another work item and move it up or down. The selected work item remains selected and the detailed view remains open.