### PR TITLE
Fixed link mocks.

### DIFF
--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -157,7 +157,7 @@ export class MockDataService {
             ]
           };
         }
-      }
+      } 
       // should never happen
       return {};
     }

--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -65,7 +65,7 @@ export class MockDataService {
 
   public createWorkItemOrEntity(extraPath: string, entity: any): any {
     if (extraPath && extraPath.indexOf('/') != -1) {
-      // request for subentities on a wi 
+      // request for subentities on a wi
       var parts = extraPath.split('/');
       var wiId = parts[0];
       var subselect = parts[1];
@@ -101,32 +101,32 @@ export class MockDataService {
     }
     var localWorkItem = this.makeCopy(entity.data);
     localWorkItem.id = this.createId();
-    localWorkItem.links = { 
+    localWorkItem.links = {
           'self': 'http://mock.service/api/workitems/id' + localWorkItem.id
         };
-    localWorkItem.relationships = { 
-          'assignees': { }, 
-          'baseType': { 
-            'data': { 
-              'id': 'system.userstory', 
-              'type': 'workitemtypes' 
-            } 
-          }, 
-          'comments': { 
-            'links': { 
+    localWorkItem.relationships = {
+          'assignees': { },
+          'baseType': {
+            'data': {
+              'id': 'system.userstory',
+              'type': 'workitemtypes'
+            }
+          },
+          'comments': {
+            'links': {
               'related': 'http://mock.service/api/workitems/id' + localWorkItem.id + '/comments',
-              'self': 'http://mock.service/api/workitems/id' + localWorkItem.id + '/relationships/comments' 
-            } 
-          }, 
-          'creator': { 
-            'data': { 
-              'id': 'user0', 
+              'self': 'http://mock.service/api/workitems/id' + localWorkItem.id + '/relationships/comments'
+            }
+          },
+          'creator': {
+            'data': {
+              'id': 'user0',
               'links': {
                 'self': 'http://mock.service/api/users/some-creator-id'
               },
-              'type': 'identities' 
-            } 
-          } 
+              'type': 'identities'
+            }
+          }
         };
     this.workItems.push(localWorkItem);
     return { data: this.makeCopy(localWorkItem) };
@@ -134,7 +134,7 @@ export class MockDataService {
 
   public getWorkItemOrEntity(extraPath: string): any {
     if (extraPath && extraPath.indexOf('/') != -1) {
-      // request for subentities on a wi 
+      // request for subentities on a wi
       var parts = extraPath.split('/');
       var wiId = parts[0];
       var subselect = parts[1];
@@ -147,9 +147,17 @@ export class MockDataService {
         console.log('Request for relationships for workitem ' + wiId);
         if (parts[2] === 'links') {
           var links = this.getWorkItemLinksForWorkItem(wiId);
-          return { data: links, meta: { totalCount: links.length } };
+          return {
+            data: links,
+            meta: { totalCount: links.length },
+            included: [
+              this.workItems[0],
+              this.workItems[1],
+              this.schemaMockGenerator.getWorkItemLinkTypes().data[0 ]
+            ]
+          };
         }
-      } 
+      }
       // should never happen
       return {};
     }
@@ -194,10 +202,12 @@ export class MockDataService {
 
   public getWorkItemLinksForWorkItem(workItemId: string): any {
     var result: any = [];
-    for (var i = 0; i < this.workItemLinks.length; i++)
-      if (this.workItemLinks[i].relationships.source.data.id === workItemId) {
+    for (var i = 0; i < this.workItemLinks.length; i++) {
+      if (this.workItemLinks[i].relationships.source.data.id === workItemId ||
+          this.workItemLinks[i].relationships.target.data.id === workItemId) {
         result.push(this.makeCopy(this.workItemLinks[i]));
       }
+    }
     return result;
   }
 

--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -141,9 +141,15 @@ export class MockDataService {
       if (subselect === 'comments') {
         console.log('Requested comments for workitem ' + wiId);
         if (this.workItemComments[wiId])
-        return this.makeCopy(this.workItemComments[wiId]);
+          return this.makeCopy(this.workItemComments[wiId]);
         return { data: [] };
-      }
+      } else if (subselect === 'relationships') {
+        console.log('Request for relationships for workitem ' + wiId);
+        if (parts[2] === 'links') {
+          var links = this.getWorkItemLinksForWorkItem(wiId);
+          return { data: links, meta: { totalCount: links.length } };
+        }
+      } 
       // should never happen
       return {};
     }
@@ -184,6 +190,15 @@ export class MockDataService {
 
   public getWorkItemLinks(): any {
     return this.makeCopy(this.workItemLinks);
+  }
+
+  public getWorkItemLinksForWorkItem(workItemId: string): any {
+    var result: any = [];
+    for (var i = 0; i < this.workItemLinks.length; i++)
+      if (this.workItemLinks[i].relationships.source.data.id === workItemId) {
+        result.push(this.makeCopy(this.workItemLinks[i]));
+      }
+    return result;
   }
 
   public createWorkItemLink(workItemLink: any): any {

--- a/src/app/shared/mock-data/work-item-mock-generator.ts
+++ b/src/app/shared/mock-data/work-item-mock-generator.ts
@@ -43,8 +43,7 @@ export class WorkItemMockGenerator {
    * Creates an initial work item links structure.
    */
   public createWorkItemLinks(): any {
-    return { 
-      data: [ 
+    return [ 
         {
           id: 'wil-0',
           type: 'workitemlinks',
@@ -75,11 +74,7 @@ export class WorkItemMockGenerator {
             }
           }
         }
-      ],
-      'meta': {
-        'totalCount': 1
-      }
-    };
+    ];
   }
   public dateTime(numberDate: any): any {
     // numberDate is mock work item id's

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -164,7 +164,8 @@ export class MockHttp extends Http {
             return this.createResponse(url.toString(), 500, 'error: no search term given.', { } );
           }
         case '/workitemlinks':
-          return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinks() );
+          var workItemLinks = this.mockDataService.getWorkItemLinks();
+          return this.createResponse(url.toString(), 200, 'ok', { data: workItemLinks, 'meta': { 'totalCount': workItemLinks.length} } );
         case '/workitemlinktypes':
           return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinkTypes() );
         case '/workitemlinkcategories':


### PR DESCRIPTION
Fixes a problem with the mock of links. Extends the functionality following the core api to retrieve single sets of links connected to a work item.