### PR TITLE
Make tests actually fail

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -45,7 +45,7 @@ docker exec almighty-ui-builder npm run build:prod
 docker exec -u root almighty-ui-builder cp -r /home/almighty/dist /
 
 ## All ok, deploy
-docker build -t almighty-ui-deploy -f Dockerfile.deploy . && \
-docker tag almighty-ui-deploy registry.ci.centos.org:5000/almighty/almighty-ui:latest && \
+docker build -t almighty-ui-deploy -f Dockerfile.deploy .
+docker tag almighty-ui-deploy registry.ci.centos.org:5000/almighty/almighty-ui:latest
 docker push registry.ci.centos.org:5000/almighty/almighty-ui:latest
 

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -3,6 +3,9 @@
 # Show command before executing
 set -x
 
+# Exit on error
+set -e
+
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 if [ -e "jenkins-env" ]; then
@@ -32,41 +35,17 @@ docker exec almighty-ui-builder npm install
 ## Exec unit tests
 docker exec almighty-ui-builder ./run_unit_tests.sh
 
-if [ $? -eq 0 ]; then
-  echo 'CICO: unit tests OK'
-else
-  echo 'CICO: unit tests FAIL'
-  exit 1
-fi
 
 ## Exec functional tests
 docker exec almighty-ui-builder ./run_functional_tests.sh
 
-if [ $? -eq 0 ]; then
-  echo 'CICO: functional tests OK'
-  docker exec almighty-ui-builder ./upload_to_codecov.sh
+docker exec almighty-ui-builder ./upload_to_codecov.sh
 
-  docker exec almighty-ui-builder npm run build:prod
-  docker exec -u root almighty-ui-builder cp -r /home/almighty/dist /
-  ## All ok, deploy
-  if [ $? -eq 0 ]; then
-    echo 'CICO: build OK'
-    docker build -t almighty-ui-deploy -f Dockerfile.deploy . && \
-    docker tag almighty-ui-deploy registry.ci.centos.org:5000/almighty/almighty-ui:latest && \
-    docker push registry.ci.centos.org:5000/almighty/almighty-ui:latest
-    if [ $? -eq 0 ]; then
-      echo 'CICO: image pushed, ready to update deployed app'
-      exit 0
-    else
-      echo 'CICO: Image push to registry failed'
-      exit 2
-    fi
-  else
-    echo 'CICO: app tests Failed'
-    exit 1
-  fi
-else
-  echo 'CICO: functional tests FAIL'
-  exit 1
-fi
+docker exec almighty-ui-builder npm run build:prod
+docker exec -u root almighty-ui-builder cp -r /home/almighty/dist /
+
+## All ok, deploy
+docker build -t almighty-ui-deploy -f Dockerfile.deploy . && \
+docker tag almighty-ui-deploy registry.ci.centos.org:5000/almighty/almighty-ui:latest && \
+docker push registry.ci.centos.org:5000/almighty/almighty-ui:latest
 

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -3,6 +3,8 @@
 # Show command before executing
 set -x
 
+set -e
+
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 if [ -e "jenkins-env" ]; then
@@ -34,25 +36,12 @@ docker exec almighty-ui-builder npm install
 ## Exec unit tests
 docker exec almighty-ui-builder ./run_unit_tests.sh
 
-if [ $? -eq 0 ]; then
-  echo 'CICO: unit tests OK'
-else
-  echo 'CICO: unit tests FAIL'
-  exit 1
-fi
 
 ## Exec functional tests
 docker exec almighty-ui-builder ./run_functional_tests.sh
 
 ## All ok, build prod version
-if [ $? -eq 0 ]; then
-  echo 'CICO: functional tests OK'
-  docker exec almighty-ui-builder ./upload_to_codecov.sh
-
-  docker exec almighty-ui-builder npm run build:prod
-  docker exec -u root almighty-ui-builder cp -r /home/almighty/dist /
-else
-  echo 'CICO: functional tests FAIL'
-  exit 1
-fi
+docker exec almighty-ui-builder ./upload_to_codecov.sh
+docker exec almighty-ui-builder npm run build:prod
+docker exec -u root almighty-ui-builder cp -r /home/almighty/dist /
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,13 @@
   },
   "angularCompilerOptions": {
     "genDir": "./ngfactory"
-  }
+  },
+  "exclude": [
+        "node_modules",
+        "**/*.d.ts",
+        "src-library/*",
+        "**/*.spec.ts"
+    ]
 }
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,13 +19,7 @@
   },
   "angularCompilerOptions": {
     "genDir": "./ngfactory"
-  },
-  "exclude": [
-        "node_modules",
-        "**/*.d.ts",
-        "src-library/*",
-        "**/*.spec.ts"
-    ]
+  }
 }
 
 


### PR DESCRIPTION
This ensures that failed tests are detected by exiting the cico_*.sh scripts as soon as an error occured. I've added the `set -e` switch to exit on error and that allowed me to remove all the check for the last error code.