### PR TITLE
Comment input field as almEditable element, fixes #722

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
@@ -3,12 +3,12 @@
         <!-- Refactoring needed to toogle view -->
         <div class="col-md-12 col-sm-12 col-xs-12" *ngIf="true">
             <div *ngIf="loggedIn" class="">
-                <textarea rows="2" type="text" id="wi-comment-add-comment" class="form-control width100" [(ngModel)]="comment.attributes.body"
-                    [style.height]="descHeight" [style.resize]="descResize" (keydown.enter)="createComment($event)" (keyup.enter)="preventDef($event)"
-                    placeholder="Add a comment here...">
-                </textarea>
+                <p almEditable id="wi-comment-add-comment" class="form-control placeholder width100"
+                    (focus)="resetCommentDraft($event)" (blur)="resetCommentDraft($event)"
+                    (keydown.enter)="createComment($event)" (keyup.enter)="preventDef($event)"
+                    data-placeholder="Add a new comment..." #comment></p>
             </div>
-            <div *ngFor='let comment of workItem.relationalData?.comments?.slice()' class="comments-wrap">
+            <div *ngFor='let comment of workItem.relationalData?.comments?.slice(); let counter = index' class="comments-wrap">
                 <div>
                     <div class="user-avatar pull-left">
                         <img id="{{'comment_avatar_' + counter}}"

--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.scss
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.scss
@@ -9,6 +9,19 @@
     > div{
         padding: 0;
     }
+    #wi-comment-add-comment {
+        /* Overrides pf's form-control style's height property */
+        /* The min-height is needed to avoid zero-height element */
+        /* The min-height is same as form-control's default height */
+        height: auto;
+        min-height: 26px;
+
+        /* Helper class, should be moved out when almEditable is extended to support placeholders */
+        &.placeholder {
+            color: $color-pf-black-400;
+            font-style: italic;
+        }
+    }
     .comments-wrap {
         width: $width100;
         float: left;

--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.ts
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.ts
@@ -33,6 +33,15 @@ export class WorkItemCommentComponent implements OnInit, OnChanges {
         this.createCommentObject();
     }
 
+    ngAfterViewInit() {
+        let commentbox = document.querySelector("#wi-comment-add-comment") as HTMLParagraphElement;
+
+        if (!!commentbox) {
+            commentbox.textContent = commentbox.dataset['placeholder'];
+            commentbox.blur();
+        }
+    }
+
     ngOnChanges(changes: SimpleChanges) {}
 
     createCommentObject(): void {
@@ -43,14 +52,29 @@ export class WorkItemCommentComponent implements OnInit, OnChanges {
 
     createComment(event: any = null): void {
         this.preventDef(event);
+        this.comment.attributes.body = event.target.textContent;
         this.workItemService
             .createComment(this.workItem['id'], this.comment)
             .then(response => {
-              this.createCommentObject();
+                event.target.textContent = "";
+                this.createCommentObject();
             })
             .catch ((error) => {
                 console.log(error);
             });
+    }
+
+    resetCommentDraft(event: any = null): void {
+        let commentbox  = event.target,
+            placeholder = event.target.dataset.placeholder;
+
+        if (event.type === 'focus' && commentbox.textContent === placeholder) {
+            commentbox.classList.remove("placeholder");
+            commentbox.textContent = '';
+        } else if (event.type === 'blur' && commentbox.textContent === '') {
+            commentbox.classList.add("placeholder");
+            commentbox.textContent = placeholder;
+        }
     }
 
     preventDef(event: any) {

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -621,13 +621,16 @@ export class WorkItemService {
    */
   createComment(id: string, comment: Comment): Promise<Comment> {
     let c = new CommentPost();
+
     c.data = comment;
+
     return this.http
       .post(this.workItems[this.workItemIdIndexMap[id]]
               .relationships.comments.links.related, c, { headers: this.headers })
       .toPromise()
       .then(response => {
         let comment: Comment = response.json().data as Comment;
+
         comment.relationalData = {
           creator : this.getUserById(comment.relationships['created-by'].data.id)
         };


### PR DESCRIPTION
- Replaces textarea with contenteditable div, by almEditable directive
- Fixes an index counter issue introduced by #731, that was breaking tests
- Workflow fixes for the new element (content reset on various actions)
- Optimized the way insertion into comment collection for a WI was being handled

Signed-off-by: Soumya Deb <debloper@gmail.com>