### PR TITLE
Change "Sign in with GitHub" button to "Sign in with Red Hat Developers

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -12,8 +12,7 @@
     <div class="col-sm-7 col-md-6 col-lg-5 login">
       <form  id="login_githubLoginForm" class="form-horizontal" role="form">
         <button (click)="gitSignin()" id="login_githubLoginBtn" class="btn btn-primary btn-lg" >
-            <span class='fa fa-github'></span>
-            Sign In with Github
+            Sign In with Red Hat Developers
         </button>
       </form>
       <div *ngIf="showError" class="alert alert-danger alert-error" id="login_githubLoginErrorAlert">


### PR DESCRIPTION
We switched to keycloak authentication instead of github in almighty-core. Our keycloak uses developers.redhat.com as Identity Provider. So we change the sign in button.

Fixes #780