### PR TITLE
Fix display of names in work item create dialog

### DIFF
--- a/src/app/work-item/work-item.component.html
+++ b/src/app/work-item/work-item.component.html
@@ -9,7 +9,7 @@
       <li *ngFor="let type of workItemTypes" (click)="onChangeType(type.name)">
         <div class="wiTypeListBlk">
           <i almIcon [iconType]="type.name" class="xl-font"></i>
-          <p>{{type.name.substring(7, type.length)}}</p>
+          <p>{{type.name}}</p>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
As of https://github.com/almighty/almighty-core/commit/7a5b4fd32588eb7304bea7a72746f0894bae1cf5 we no longer store WIT names with the `"system."` prefix. Hence, we must not strip-off 7 characters in  front of WIT names when displaying.

When you click this button in the top right corner 
![bildschirmfoto von 2017-01-19 23-35-53](https://cloud.githubusercontent.com/assets/193408/22128285/165093b2-dea0-11e6-9e44-620a86d41260.png)

you get this without this change:
![bildschirmfoto von 2017-01-19 23-35-37](https://cloud.githubusercontent.com/assets/193408/22128309/27ee4678-dea0-11e6-8d8a-c63900db75b3.png)

Quite obviously somebody removed the first 7 characters and not just left trims any occurence of "system.".
