### PR TITLE
Remove reordering of comments in UI

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
@@ -8,7 +8,7 @@
                     placeholder="Add a comment here...">
                 </textarea>
             </div>
-            <div *ngFor='let comment of workItem.relationalData?.comments?.slice().reverse()' class="comments-wrap">
+            <div *ngFor='let comment of workItem.relationalData?.comments?.slice()' class="comments-wrap">
                 <div>
                     <div class="user-avatar pull-left">
                         <img id="{{'comment_avatar_' + counter}}"

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -618,11 +618,7 @@ export class WorkItemService {
         };
         this.workItems[this.workItemIdIndexMap[id]]
           .relationalData
-          .comments.splice(
-            this.workItems[this.workItemIdIndexMap[id]]
-              .relationalData.comments.length,
-            0,
-            comment);
+          .comments.unshift(comment);
         return comment;
       })
       .catch (this.handleError);


### PR DESCRIPTION
Comments from backend are now in correct order and paginated.

Related to fabric8io/fabric8-planner#729