### PR TITLE
Remove 'system.' prefix from the quick add work item form (#783).

### DIFF
--- a/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
+++ b/src/app/work-item/work-item-quick-add/work-item-quick-add.component.ts
@@ -59,7 +59,7 @@ export class WorkItemQuickAddComponent implements OnInit, AfterViewInit {
     this.workItem.relationships = {
       baseType: {
         data: {
-          id: 'system.userstory',
+          id: 'userstory',
           type: 'workitemtypes'
         }
       }


### PR DESCRIPTION
Remove 'system.' prefix from the quick add work item form (#783).

Note that this is a temporary fix to enable quick add.

We can use 798 to track the discussion and implementation of dynamic setting of the quick add work item type.