### PR TITLE
fix: Update Visuals for Title Add/Edit on WI Detail

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.html
@@ -33,36 +33,36 @@
           <div class="col-md-8 col-sm-7 col-xs-12 wi-detail-title-blk">
             <div *ngIf="!headerEditable" (click)='openHeader()'
               id="title-click-div">
-                <h2 *ngIf="!loggedIn" id="wi-detail-title-ne" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
-                <h2 *ngIf="loggedIn" id="wi-detail-title-click" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
-                <span *ngIf="loggedIn && workItem.id"
-                  class="pficon-edit marginL10 fl detail-title-edit-ico"
-                  id="workItemTitle_btn_edit"></span>
+              <h2 *ngIf="!loggedIn" id="wi-detail-title-ne" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
+              <h2 *ngIf="loggedIn" id="wi-detail-title-click" class="detail-title truncate">{{ workItem.attributes['system.title'] }}</h2>
+              <span *ngIf="loggedIn && workItem.id"
+                class="pficon-edit marginL10 fl detail-title-edit-ico"
+                id="workItemTitle_btn_edit"></span>
             </div>
             <div *ngIf="(loggedIn && headerEditable)" id="wi-title-div">
-                <div almEditable
+                <h2 almEditable
                     (onUpdate)="checkTitle($event)"
                     (keyup.enter)="onUpdateTitle()"
                     (keydown.enter)="preventDef($event)"
                     id="wi-detail-title"
-                    class="detail-title-edit"
+                    class="detail-title-edit form-control"
                     [innerText]="workItem.attributes['system.title'] | almTrim"
                     #title >
-                </div>
+                </h2>
                 <aside class="col-md-12 col-sm-12 col-xs-12">
+                  <!--Cancel icon-->
+                  <button id="workItemTitle_btn_cancel"
+                      class="pull-right btn btn-default detail-action-btn"
+                      (click)="closeHeader()">
+                    <span class="fa fa-close"></span>
+                  </button>
                   <!--Save icon-->
-                  <div id="workItemTitle_btn_save"
-                      class="pull-right btn-small detail-action-btn"
+                  <button id="workItemTitle_btn_save"
+                      class="pull-right btn btn-default detail-action-btn"
                       [ngClass]="{disabled : validTitle == false}"
                       (click)="validTitle && onUpdateTitle()" >
                       <span class="fa fa-check"></span>
-                  </div>
-                  <!--Cancel icon-->
-                  <div id="workItemTitle_btn_cancel"
-                      class="pull-right btn-small detail-action-btn"
-                      (click)="closeHeader()">
-                    <span class="fa fa-close"></span>
-                  </div>
+                  </button>
                 </aside>
                 <!--Error message for title-->
                 <p [hidden]="validTitle"

--- a/src/app/work-item/work-item-detail/work-item-detail.component.scss
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.scss
@@ -65,12 +65,9 @@
       cursor: pointer;
     }
     .detail-title-edit {
-      border-bottom: 1px solid $color-pf-blue-200;
-      @include box-shadow(0 4px 4px -4px rgba(0,136,206,.6));
-      font-size: em(22);
-      outline: 0;
-      line-height: 1.3;
-      min-height: em(17);
+      min-height: em(25);
+      margin: 0;
+      line-height: 1.5;
     }
     aside{
       padding: em(5) 0 0;
@@ -221,10 +218,9 @@
   .detail-action-btn {
     font-size: em(14);
     cursor: pointer;
-    width:em(24);
+    width:em(42);
     text-align: $textCenter;
     padding: em(5);
-    background-color: $color-pf-black-200;
     margin-left: em(5);
   }
   .desc-editable {

--- a/src/app/work-item/work-item-detail/work-item-detail.component.scss
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.scss
@@ -58,7 +58,8 @@
       float: left;
       max-width: calc(100% - 25px);
       margin:0;
-      line-height: 1.3;
+      line-height: 1.5;
+      padding: em(2) em(4.5);
     }
     .detail-title-edit-ico {
       line-height: 2;


### PR DESCRIPTION
Update UI for Title Add/Edit on WI Detail Page as per Visuals

#875 
<img width="483" alt="screen shot 2017-02-06 at 12 42 59 pm" src="https://cloud.githubusercontent.com/assets/10396359/22637801/25fab5cc-ec6a-11e6-84c0-65ac0d5970c7.png">
