### PR TITLE
Fix multiple element detection warning in iteration help-block

### DIFF
--- a/src/app/iteration/iteration-modal/iteration-modal.component.html
+++ b/src/app/iteration/iteration-modal/iteration-modal.component.html
@@ -16,7 +16,7 @@
               placeholder="Enter iteration name"
               [(ngModel)]="iteration.attributes.name"
               (keyup)="removeError()">
-            <span class="help-block">Iteration names must be unique within a project</span>
+            <span class="help-block" id="iteration-help-label">Iteration names must be unique within a project</span>
           </div>
         </div>
         <div class="form-group">

--- a/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -487,7 +487,7 @@ class WorkItemListPage {
     return element(by.css('.modal-title')).getText();
   }
   getHelpBoxIteration (){
-    return element(by.css('.help-block')).getText();
+    return element(by.id('iteration-help-label')).getText();
   }
   closeIterationDialog(){
     return element(by.css('.close')).click();


### PR DESCRIPTION
The warning
`Started
...........................................[09:46:23] W/element - more than one element found for locator By(css selector, .help-block) - the first result will be used
....................................`
Use to show up for iterations , fixed in this PR
