### PR TITLE
Added tree list component

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@angular/upgrade": "2.1.1",
     "@types/lodash": "4.14.41",
     "angular-in-memory-web-api": "0.1.13",
+    "angular2-tree-component": "^2.7.0",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "lodash": "4.17.2",

--- a/src/app/shared-component/treelist/treelist.component.html
+++ b/src/app/shared-component/treelist/treelist.component.html
@@ -1,0 +1,45 @@
+<Tree #tree
+      [nodes]="nodes"
+      [focused]="true"
+      [options]="customOptions">
+  <template #treeNodeTemplate let-node let-index="index">
+    <template [ngTemplateOutlet]="listTemplate" [ngOutletContext]="{ item: node, index: index }"></template>
+  </template>
+  <template #loadingTemplate>Loading, please hold....</template>
+  <template #treeNodeFullTemplate
+            let-node="node"
+            let-index="index"
+            let-templates="templates">
+    <div
+      *ngIf="!node.isHidden"
+      class="tree-node tree-node-level-{{ node.level }}"
+      [class]="node.getClass()"
+      [class.tree-node-expanded]="node.isExpanded && node.hasChildren"
+      [class.tree-node-collapsed]="node.isCollapsed && node.hasChildren"
+      [class.tree-node-leaf]="node.isLeaf"
+      [class.tree-node-active]="node.isActive"
+      [class.tree-node-focused]="node.isFocused">
+
+      <TreeNodeDropSlot *ngIf="index === 0" [dropIndex]="index" [node]="node.parent"></TreeNodeDropSlot>
+
+      <div class="node-wrapper" [style.padding-left]="node.getNodePadding()">
+        <TreeNodeExpander [node]="node" *ngIf="!hideExpander"></TreeNodeExpander>
+        <div class="node-content-wrapper"
+             (click)="node.mouseAction('click', $event)"
+             (dblclick)="node.mouseAction('dblClick', $event)"
+             (contextmenu)="node.mouseAction('contextMenu', $event)"
+             (treeDrop)="node.onDrop($event)"
+             [treeAllowDrop]="node.allowDrop.bind(node)"
+             [treeDrag]="node"
+             [treeDragEnabled]="node.allowDrag()">
+
+          <TreeNodeContent [node]="node" [index]="index" [template]="templates.treeNodeTemplate">
+          </TreeNodeContent>
+        </div>
+      </div>
+
+      <TreeNodeChildren [node]="node" [templates]="templates"></TreeNodeChildren>
+      <TreeNodeDropSlot [dropIndex]="index + 1" [node]="node.parent"></TreeNodeDropSlot>
+    </div>
+  </template>
+</Tree>

--- a/src/app/shared-component/treelist/treelist.component.scss
+++ b/src/app/shared-component/treelist/treelist.component.scss
@@ -1,0 +1,79 @@
+@import "../../../assets/stylesheets/custom";
+
+.tree-list {
+  .node-content-wrapper {
+    display: inherit;
+    padding: 0;
+    border-radius: inherit;
+    transition: none;
+  }
+
+  /*
+  // Todo: drop area
+  .node-drop-slot {
+    height: 2px;
+  }
+  .node-drop-slot.is-dragging-over {
+    height: 55px;
+  }
+  */
+
+  .toggle-children-wrapper {
+    padding: 0px;
+  }
+
+  // Toggle up
+  .toggle-children {
+    background-image: none;
+    background-position: inherit;
+    background-repeat: inherit;
+    display: block;
+    font-family: FontAwesome;
+    font-size: inherit;
+    height: inherit;
+    padding-right: 10px;
+    position: inherit;
+    top: inherit;
+    vertical-align: middle;
+    width: inherit;
+    &:before {
+      content: "\f105";
+    }
+  }
+
+  // Toggle up
+  .toggle-children-wrapper-collapsed .toggle-children {
+    transform: none;
+  }
+
+  // Toggle down
+  .toggle-children-wrapper-expanded .toggle-children {
+    transform: none;
+    &:before {
+      content: "\f107";
+    }
+  }
+
+  // Toggle indentation -- row highlighting should occupy entire width
+  .tree-children {
+    padding-left: 0;
+    .toggle-children {
+      padding-left: 20px;
+    }
+    .tree-children {
+      .toggle-children {
+        padding-left: 40px;
+      }
+      .tree-children {
+        .toggle-children {
+          padding-left: 60px;
+        }
+        .tree-children {
+          .toggle-children {
+            padding-left: 80px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/app/shared-component/treelist/treelist.component.scss
+++ b/src/app/shared-component/treelist/treelist.component.scss
@@ -8,15 +8,14 @@
     transition: none;
   }
 
-  /*
   // Todo: drop area
   .node-drop-slot {
-    height: 2px;
+    height: 4px;
   }
+
   .node-drop-slot.is-dragging-over {
-    height: 55px;
+    height: 70px;
   }
-  */
 
   .toggle-children-wrapper {
     padding: 0px;

--- a/src/app/shared-component/treelist/treelist.component.spec.ts
+++ b/src/app/shared-component/treelist/treelist.component.spec.ts
@@ -1,0 +1,152 @@
+import {
+  async,
+  ComponentFixture,
+  fakeAsync,
+  inject,
+  TestBed,
+  tick
+} from '@angular/core/testing';
+
+import { DebugElement } from '@angular/core';
+import { FormsModule }  from '@angular/forms';
+import { By }           from '@angular/platform-browser';
+
+import { TreeModule } from 'angular2-tree-component';
+import { TreeListComponent } from './treelist.component';
+import { User } from '../../models/user';
+import { WorkItem } from '../../models/work-item';
+
+describe('Treelist component - ', () => {
+  let comp: TreeListComponent;
+  let fixture: ComponentFixture<TreeListComponent>;
+  let el: DebugElement;
+  let fakeUserList: User[];
+  let fakeWorkItem: WorkItem;
+  let fakeWorkItems: WorkItem[] = [];
+  let fakeWorkItemsWithChild: any[] = [];
+
+  let treeListOptions = {
+    allowDrag: true
+  }
+
+  beforeEach(() => {
+    fakeUserList = [
+      {
+        attributes: {
+          fullName: 'WILCT Example User 0',
+          imageURL: 'https://avatars.githubusercontent.com/u/2410471?v=3'
+        },
+        id: 'wilct-user0'
+      }, {
+        attributes: {
+          fullName: 'WILCT Example User 1',
+          imageURL: 'https://avatars.githubusercontent.com/u/2410472?v=3'
+        },
+        id: 'wilct-user1'
+      }, {
+        attributes: {
+          fullName: 'WILCT Example User 2',
+          imageURL: 'https://avatars.githubusercontent.com/u/2410473?v=3'
+        },
+        id: 'wilct-user2'
+      }
+    ] as User[];
+
+    fakeWorkItem = {
+      'attributes': {
+        'system.created_at': null,
+        'system.description': null,
+        'system.remote_item_id': null,
+        'system.state': 'new',
+        'system.title': 'test1',
+        'version': 0
+      },
+      'id': '1',
+      'relationships': {
+        'assignees': {
+          'data': [{
+            'id': 'wilct-user2',
+            'type': 'identities'
+          }]
+        },
+        'baseType': {
+          'data': {
+            'id': 'system.userstory',
+            'type': 'workitemtypes'
+          }
+        },
+        'creator': {
+          'data': {
+            'id': 'wilct-user2',
+            'type': 'identities'
+          }
+        },
+        'comments': {
+          'links': {
+            'self': '',
+            'related': ''
+          }
+        }
+      },
+      'type': 'workitems',
+      'relationalData': {
+        'creator': fakeUserList[0],
+        'assignees': [fakeUserList[2]]
+      }
+    } as WorkItem;
+
+    fakeWorkItems.push(Object.assign({}, fakeWorkItem));
+    fakeWorkItemsWithChild.push(Object.assign({}, fakeWorkItem));
+    fakeWorkItemsWithChild[0].children = [ Object.assign({}, fakeWorkItem, { id: '2'}) ];
+  });
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule, TreeModule],
+      declarations: [TreeListComponent]
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(TreeListComponent);
+        comp = fixture.componentInstance;
+      });
+  }));
+
+  it('Should have at least one node', () => {
+    comp.nodes = fakeWorkItems;
+    comp.options = treeListOptions;
+    fixture.detectChanges();
+    el = fixture.debugElement.query(By.css('.tree-list'));
+    expect(el).toBeDefined();
+  });
+
+  it('Should not have toggle to expand tree', () => {
+    comp.nodes = fakeWorkItems;
+    comp.options = treeListOptions;
+    fixture.detectChanges();
+    el = fixture.debugElement.query(By.css('.tree-list.tree-node-collapsed'));
+    expect(el).toBeNull();
+  });
+
+  it('Should have toggle to expand tree', () => {
+    comp.nodes = fakeWorkItemsWithChild;
+    comp.options = treeListOptions;
+    fixture.detectChanges();
+    el = fixture.debugElement.query(By.css('.tree-list.tree-node-collapsed'));
+    expect(el).toBeDefined();
+  });
+
+  it('Should expand tree node on click', () => {
+    comp.nodes = fakeWorkItemsWithChild;
+    comp.options = treeListOptions;
+    fixture.detectChanges();
+    el = fixture.debugElement.query(By.css('.tree-list .toggle-children-wrapper-collapsed'));
+    expect(el).toBeDefined();
+
+    // Click on the label to open the list
+    el.triggerEventHandler('click', {});
+    fixture.detectChanges();
+    el = fixture.debugElement.query(By.css('.tree-list .toggle-children-wrapper-expanded'));
+    expect(el).toBeDefined();
+  });
+});

--- a/src/app/shared-component/treelist/treelist.component.ts
+++ b/src/app/shared-component/treelist/treelist.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { TreeNode, TREE_ACTIONS, KEYS, IActionMapping, TreeComponent } from 'angular2-tree-component';
+
+// See docs: https://angular2-tree.readme.io/docs
+@Component({
+  selector: 'alm-tree-list',
+  templateUrl: './treelist.component.html',
+  styleUrls: ['./treelist.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+
+export class TreeListComponent {
+  @Input() nodes: any[] = null;
+  @Input() hideExpander: boolean;
+  @Input() listTemplate: TemplateRef<any>;
+  @Input() options:any;
+
+  @ViewChild(TreeComponent) tree: TreeComponent;
+  @ViewChild('treeNodeTemplate') listItemTemplate: TemplateRef<any>;
+
+  // Default key actions
+  actionMapping:IActionMapping = {
+    mouse: {
+      dblClick: (tree, node, $event) => {
+        if (node.hasChildren) TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);
+      },
+      click: (tree, node, $event) => {
+        TREE_ACTIONS.TOGGLE_SELECTED(tree, node, $event)
+      }
+    }
+  };
+
+  // Defaults
+  defaultOptions = {
+    actionMapping: this.actionMapping,
+    nodeClass: (node: TreeNode) => {
+      return 'tree-list';
+    }
+  }
+  customOptions = this.defaultOptions;
+
+  constructor() {
+    // Override default options
+    setTimeout(() => {
+      Object.assign(this.customOptions, this.options);
+    }, 1);
+  }
+
+  // Helper function to update tree when moving items
+  updateTree() {
+    this.tree.treeModel.update();
+  }
+}

--- a/src/app/shared-component/treelist/treelist.module.ts
+++ b/src/app/shared-component/treelist/treelist.module.ts
@@ -1,0 +1,25 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+import { TreeModule } from 'angular2-tree-component';
+
+import { TreeListComponent } from './treelist.component';
+
+@NgModule({
+  declarations: [
+    TreeListComponent
+  ],
+  imports: [
+    BrowserModule,
+    CommonModule,
+    FormsModule,
+    HttpModule,
+    TreeModule
+  ],
+  providers: [],
+  bootstrap: [ TreeListComponent ],
+  exports: [ TreeListComponent ]
+})
+export class TreeListModule { }

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -5,6 +5,7 @@
 	></alm-dialog>
 </div>
 <div class="list-group-item" (click)="onSelect($event)" [class.selected]="isSelected()">
+  <TreeNodeExpander [node]="node"></TreeNodeExpander>
 	<!--checkbox to select a WI and move it-->
 	<div class="row-cbh" title="Select the checkbox to move the item.">
 		<input type="checkbox" [checked]="checkedWI" (click)="toggleEntry($event)" />

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
@@ -37,6 +37,8 @@ import { WorkItemService } from '../../work-item.service';
 export class WorkItemListEntryComponent implements OnInit {
 
   @Input() workItem: WorkItem;
+  @Input() node: any;
+
   @Output() toggleEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() selectEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() detailEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -1,35 +1,31 @@
 <div class="work-item-list-page">
-
   <div #listContainer
-      almInfiniteScroll
-      class="detail-list-wrap list-group list-view-pf"
-      [eachElementHeightInPx]='contentItemHeight'
-      (initItems)='initWiItems($event)'
-      (fetchMore)='fetchMoreWiItems()'>
-    <div dnd-sortable-container
-        [sortableData]="workItems"
-        *ngIf="workItems">
-      <div *ngFor="let workItem of workItems; let counter = index"
-          dnd-sortable
-          [sortableIndex]="counter"
-          (onDragStart)="onDragStart()"
-          (onDragEnd)="onDragEnd(workItem.id)"
-          [attr.data-id]="workItem.id"
-          id="work-item-{{workItem.id}}">
+       almInfiniteScroll
+       class="detail-list-wrap list-group list-view-pf"
+       [eachElementHeightInPx]='contentItemHeight'
+       (initItems)='initWiItems($event)'
+       (fetchMore)='fetchMoreWiItems()'>
+    <alm-tree-list #treeList
+        [nodes]="workItems"
+        [hideExpander]="true"
+        [listTemplate]="listItemTemplate"
+        [options]="treeListOptions">
+      <template #template let-item="item" let-index="index">
         <alm-work-item-list-entry
-          id="{{'workItemList_OuterWrap_'+counter}}"
+          id="{{'workItemList_OuterWrap_' + index}}"
           class="work-item-list-entry"
-          [workItem]="workItem"
+          [workItem]="item.data"
+          [node]="item"
           (toggleEvent)="onToggle($event)"
           (selectEvent)="onSelect($event)"
           (detailEvent)="onDetail($event)"
           (moveTopEvent)="onMoveToTop($event)"
           (moveBottomEvent)="onMoveToBottom($event)">
         </alm-work-item-list-entry>
-      </div>
-      <div *ngIf="!workItems.length">
-        <h2 class="error no-wi">No workitems were found!</h2>
-      </div>
+      </template>
+    </alm-tree-list>
+    <div *ngIf="!workItems.length">
+      <h2 class="error no-wi">No workitems were found!</h2>
     </div>
   </div>
 

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -24,7 +24,7 @@
         </alm-work-item-list-entry>
       </template>
     </alm-tree-list>
-    <div *ngIf="!workItems.length">
+    <div *ngIf="!workItems">
       <h2 class="error no-wi">No workitems were found!</h2>
     </div>
   </div>

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit,
   ViewChild,
   ViewChildren,
-  QueryList
+  QueryList, TemplateRef
 } from '@angular/core';
 import {
   Router,
@@ -24,6 +24,7 @@ import { WorkItemService }            from '../work-item.service';
 import { UserService } from '../../user/user.service';
 import { User } from '../../models/user';
 
+import { TreeListComponent } from '../../shared-component/treelist/treelist.component';
 
 @Component({
   selector: 'alm-work-item-list',
@@ -34,7 +35,10 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
 
   @ViewChildren('activeFilters', {read: ElementRef}) activeFiltersRef: QueryList<ElementRef>;
   @ViewChild('activeFiltersDiv') activeFiltersDiv: any;
+
   @ViewChild('listContainer') listContainer: any;
+  @ViewChild('template') listItemTemplate: TemplateRef<any>;
+  @ViewChild('treeList') treeList: TreeListComponent;
 
   workItems: WorkItem[];
   workItemTypes: WorkItemType[];
@@ -50,6 +54,11 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   filters: any[] = [];
   allUsers: User[] = [] as User[];
   authUser: any = null;
+
+  // See: https://angular2-tree.readme.io/docs/options
+  treeListOptions = {
+    allowDrag: true
+  }
 
   constructor(
     private auth: AuthenticationService,
@@ -92,7 +101,9 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   fetchMoreWiItems(): void {
     this.workItemService
       .getMoreWorkItems()
-      .then((newWiItems) => {})
+      .then((newWiItems) => {
+        this.treeList.updateTree();
+      })
       .catch ((e) => console.log(e));
   }
 
@@ -128,10 +139,27 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
     this.showWorkItemDetails = true;
   }
 
+  onMoveSelectedToTop(): void{
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'top').then(() => {
+      this.treeList.updateTree();
+      this.listContainer.nativeElement.scrollTop = 0;
+    });
+  }
+
+  onMoveSelectedToBottom(): void{
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'bottom').then(() => {
+      this.treeList.updateTree();
+      this.listContainer.nativeElement.scrollTop = this.workItems.length * this.contentItemHeight;
+    });
+  }
+
   onMoveToTop(entryComponent: WorkItemListEntryComponent): void {
     this.workItemDetail = entryComponent.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'top')
     .then(() => {
+      this.treeList.updateTree();
       this.listContainer.nativeElement.scrollTop = 0;
     });
   }
@@ -140,6 +168,7 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
     this.workItemDetail = entryComponent.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'bottom')
     .then(() => {
+      this.treeList.updateTree();
       this.listContainer.nativeElement.scrollTop = this.workItems.length * this.contentItemHeight;
     });
   }
@@ -147,11 +176,13 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   onMoveUp(): void {
     this.workItemDetail = this.workItemToMove.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'up');
+    this.treeList.updateTree();
   }
 
   onMoveDown(): void {
     this.workItemDetail = this.workItemToMove.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'down');
+    this.treeList.updateTree();
   }
 
   listenToEvents() {
@@ -186,8 +217,10 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
             this.onMoveDown();
             break;
           case 'top':
+            this.onMoveSelectedToTop();
             break;
-          case 'down':
+          case 'bottom':
+            this.onMoveSelectedToBottom();
             break;
           default:
             break;

--- a/src/app/work-item/work-item.module.ts
+++ b/src/app/work-item/work-item.module.ts
@@ -22,6 +22,8 @@ import { WorkItemListEntryComponent } from './work-item-list/work-item-list-entr
 import { WorkItemListComponent } from './work-item-list/work-item-list.component';
 import { WorkItemQuickAddModule } from './work-item-quick-add/work-item-quick-add.module';
 import { WorkItemRoutingModule } from './work-item-routing.module';
+import { TreeModule } from 'angular2-tree-component';
+import { TreeListModule, } from './../shared-component/treelist/treelist.module';
 
 @NgModule({
   imports: [
@@ -37,7 +39,9 @@ import { WorkItemRoutingModule } from './work-item-routing.module';
     TooltipModule,
     WorkItemDetailModule,
     WorkItemRoutingModule,
-    WorkItemQuickAddModule
+    WorkItemQuickAddModule,
+    TreeModule,
+    TreeListModule
   ],
   declarations: [
     AlmArrayFilter,


### PR DESCRIPTION
Tree nodes are not displayed by default. To enable the toggle, the WI object must have a children array. Alternatively, we can use the components getChildren function to fetch as needed. In that scenario, a hasChildren boolean can be added to the WI object to enable the toggle.

Dragging is enabled, but can be restricted using the allowDrop function.

See below for documentation regarding available options.
https://angular2-tree.readme.io/docs/options

See below for full documentation.
https://angular2-tree.readme.io/docs

Tree list with toggle
![alm-tree-list](https://cloud.githubusercontent.com/assets/17481322/22977706/c5ef42e2-f35d-11e6-8a24-ed17322f951e.png)

Tree list without toggle (default)
![alm-list](https://cloud.githubusercontent.com/assets/17481322/22977722/d0a532a0-f35d-11e6-9918-cfdf4287bb6c.png)

