### PR TITLE
Fixes the curious case of almEditable (on-demand) element focus

### DIFF
--- a/src/app/shared-component/editable/almeditable.directive.ts
+++ b/src/app/shared-component/editable/almeditable.directive.ts
@@ -51,11 +51,10 @@ export class AlmEditableDirective implements OnInit, OnChanges {
 
   makeEditable() {
     this.element.setAttribute('contenteditable', 'true');
-    this.element.focus();
   }
 
   makeNonEditable() {
-    this.element.setAttribute('contenteditable', 'null');
+    this.element.removeAttribute('contenteditable');
   }
 
   @HostListener('window:keyup', ['$event'])

--- a/src/app/work-item/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.html
@@ -213,7 +213,7 @@
           <div class="col-md-12 col-sm-12 col-xs-12 detail-description" *ngIf="loggedIn">
             <button class="view-switch-btn" *ngIf="descViewType=='markdown'" (click)="showHtml(desc.innerText)">View HTML</button>
             <button class="view-switch-btn" *ngIf="descViewType=='html'" (click)="descViewType='markdown'">View Markdown</button>
-            <div id="wi-detail-desc" class="detail-desc-div-wrap" (click)="openDescription(false, true)">
+            <div id="wi-detail-desc" class="detail-desc-div-wrap" (click)="openDescription()">
               <div class="detail-desc-div"
                 [class.desc-editable]="descEditable"
                 [class.desc-not-found]="!descEditable && !workItem.attributes['system.description']">

--- a/src/app/work-item/work-item-detail/work-item-detail.component.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.ts
@@ -159,7 +159,12 @@ export class WorkItemDetailComponent implements OnInit, AfterViewInit {
     // as this would indicate that changes are being caused by change detection itself.
     // I had to triggers another round of change detection
     // during that method - emit an event, whatever. Wrapping it in a timeout would do the job
-    setTimeout(() => this.panelState = 'in');
+    setTimeout(() => {
+      this.panelState = 'in';
+      if (this.headerEditable) {
+        this.title.nativeElement.focus();
+      }
+    });
   }
 
   loadWorkItem(id: string): void {
@@ -254,6 +259,11 @@ export class WorkItemDetailComponent implements OnInit, AfterViewInit {
       }
       this.closeRestFields();
       this.headerEditable = true;
+      setTimeout(() => {
+        if (this.headerEditable) {
+          this.title.nativeElement.focus();
+        }
+      });
     }
   }
 
@@ -265,7 +275,11 @@ export class WorkItemDetailComponent implements OnInit, AfterViewInit {
       this.closeRestFields();
       this.descEditable = true;
       this.descViewType = 'markdown';
-      setTimeout(() => this.description.nativeElement.focus());
+      setTimeout(() => {
+        if (this.descEditable) {
+          this.description.nativeElement.focus();
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Disabled almEditable automatically setting focus (often leading to weird interactions). With this patch, setting focus on the editable element is part of the interaction-flow implementation, and not default to almEditable.

This also fixes the existing cases affecting the changes in detail-view (title and descriptions - for general view as well as creating new WI).