### PR TITLE
Added treelist component

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ng2-dnd": "2.0.1",
     "ng2-dropdown": "0.0.15",
     "ng2-modal": "0.0.22",
-    "ngx-widgets": "0.2.17",
+    "ngx-widgets": "0.2.18",
     "ng2bln-count-pipe": "1.1.0",
     "obsidian-generator-frontend": "0.0.7",
     "reflect-metadata": "0.1.8",

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -5,6 +5,7 @@
 	></alm-dialog>
 </div>
 <div class="list-group-item" (click)="onSelect($event)" [class.selected]="isSelected()">
+  <TreeNodeExpander [node]="node"></TreeNodeExpander>
 	<!--checkbox to select a WI and move it-->
 	<div class="row-cbh" title="Select the checkbox to move the item.">
 		<input type="checkbox" [checked]="checkedWI" (click)="toggleEntry($event)" />

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.ts
@@ -37,6 +37,8 @@ import { WorkItemService } from '../../work-item.service';
 export class WorkItemListEntryComponent implements OnInit {
 
   @Input() workItem: WorkItem;
+  @Input() node: any;
+
   @Output() toggleEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() selectEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();
   @Output() detailEvent: EventEmitter<WorkItemListEntryComponent> = new EventEmitter<WorkItemListEntryComponent>();

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -1,35 +1,31 @@
 <div class="work-item-list-page">
-
   <div #listContainer
-      almInfiniteScroll
-      class="detail-list-wrap list-group list-view-pf"
-      [eachElementHeightInPx]='contentItemHeight'
-      (initItems)='initWiItems($event)'
-      (fetchMore)='fetchMoreWiItems()'>
-    <div dnd-sortable-container
-        [sortableData]="workItems"
-        *ngIf="workItems">
-      <div *ngFor="let workItem of workItems; let counter = index"
-          dnd-sortable
-          [sortableIndex]="counter"
-          (onDragStart)="onDragStart()"
-          (onDragEnd)="onDragEnd(workItem.id)"
-          [attr.data-id]="workItem.id"
-          id="work-item-{{workItem.id}}">
+       almInfiniteScroll
+       class="detail-list-wrap list-group list-view-pf"
+       [eachElementHeightInPx]='contentItemHeight'
+       (initItems)='initWiItems($event)'
+       (fetchMore)='fetchMoreWiItems()'>
+    <alm-tree-list #treeList
+        [nodes]="workItems"
+        [hideExpander]="true"
+        [listTemplate]="listItemTemplate"
+        [options]="treeListOptions">
+      <template #template let-item="item" let-index="index">
         <alm-work-item-list-entry
-          id="{{'workItemList_OuterWrap_'+counter}}"
+          id="{{'workItemList_OuterWrap_' + index}}"
           class="work-item-list-entry"
-          [workItem]="workItem"
+          [workItem]="item.data"
+          [node]="item"
           (toggleEvent)="onToggle($event)"
           (selectEvent)="onSelect($event)"
           (detailEvent)="onDetail($event)"
           (moveTopEvent)="onMoveToTop($event)"
           (moveBottomEvent)="onMoveToBottom($event)">
         </alm-work-item-list-entry>
-      </div>
-      <div *ngIf="!workItems.length">
-        <h2 class="error no-wi">No workitems were found!</h2>
-      </div>
+      </template>
+    </alm-tree-list>
+    <div *ngIf="!workItems || workItems.length === 0">
+      <h2 class="error no-wi">No workitems were found!</h2>
     </div>
   </div>
 

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit,
   ViewChild,
   ViewChildren,
-  QueryList
+  QueryList, TemplateRef
 } from '@angular/core';
 import {
   Router,
@@ -24,6 +24,7 @@ import { WorkItemService }            from '../work-item.service';
 import { UserService } from '../../user/user.service';
 import { User } from '../../models/user';
 
+import { TreeListComponent } from 'ngx-widgets';
 
 @Component({
   selector: 'alm-work-item-list',
@@ -34,7 +35,10 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
 
   @ViewChildren('activeFilters', {read: ElementRef}) activeFiltersRef: QueryList<ElementRef>;
   @ViewChild('activeFiltersDiv') activeFiltersDiv: any;
+
   @ViewChild('listContainer') listContainer: any;
+  @ViewChild('template') listItemTemplate: TemplateRef<any>;
+  @ViewChild('treeList') treeList: TreeListComponent;
 
   workItems: WorkItem[];
   workItemTypes: WorkItemType[];
@@ -50,6 +54,11 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   filters: any[] = [];
   allUsers: User[] = [] as User[];
   authUser: any = null;
+
+  // See: https://angular2-tree.readme.io/docs/options
+  treeListOptions = {
+    allowDrag: true
+  }
 
   constructor(
     private auth: AuthenticationService,
@@ -92,7 +101,9 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   fetchMoreWiItems(): void {
     this.workItemService
       .getMoreWorkItems()
-      .then((newWiItems) => {})
+      .then((newWiItems) => {
+        this.treeList.updateTree();
+      })
       .catch ((e) => console.log(e));
   }
 
@@ -128,10 +139,27 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
     this.showWorkItemDetails = true;
   }
 
+  onMoveSelectedToTop(): void{
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'top').then(() => {
+      this.treeList.updateTree();
+      this.listContainer.nativeElement.scrollTop = 0;
+    });
+  }
+
+  onMoveSelectedToBottom(): void{
+    this.workItemDetail = this.workItemToMove.getWorkItem();
+    this.workItemService.moveItem(this.workItemDetail, 'bottom').then(() => {
+      this.treeList.updateTree();
+      this.listContainer.nativeElement.scrollTop = this.workItems.length * this.contentItemHeight;
+    });
+  }
+
   onMoveToTop(entryComponent: WorkItemListEntryComponent): void {
     this.workItemDetail = entryComponent.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'top')
     .then(() => {
+      this.treeList.updateTree();
       this.listContainer.nativeElement.scrollTop = 0;
     });
   }
@@ -140,6 +168,7 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
     this.workItemDetail = entryComponent.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'bottom')
     .then(() => {
+      this.treeList.updateTree();
       this.listContainer.nativeElement.scrollTop = this.workItems.length * this.contentItemHeight;
     });
   }
@@ -147,11 +176,13 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
   onMoveUp(): void {
     this.workItemDetail = this.workItemToMove.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'up');
+    this.treeList.updateTree();
   }
 
   onMoveDown(): void {
     this.workItemDetail = this.workItemToMove.getWorkItem();
     this.workItemService.moveItem(this.workItemDetail, 'down');
+    this.treeList.updateTree();
   }
 
   listenToEvents() {
@@ -186,8 +217,10 @@ export class WorkItemListComponent implements OnInit, AfterViewInit {
             this.onMoveDown();
             break;
           case 'top':
+            this.onMoveSelectedToTop();
             break;
-          case 'down':
+          case 'bottom':
+            this.onMoveSelectedToBottom();
             break;
           default:
             break;

--- a/src/app/work-item/work-item.module.ts
+++ b/src/app/work-item/work-item.module.ts
@@ -27,6 +27,8 @@ import { WorkItemQuickAddModule } from './work-item-quick-add/work-item-quick-ad
 import { AuthUserResolve, IterationsResolve, UsersResolve } from './common.resolver';
 import { WorkItemComponent } from './work-item.component';
 import { WorkItemRoutingModule } from './work-item-routing.module';
+import { TreeModule } from 'angular2-tree-component';
+import { TreeListModule, } from 'ngx-widgets';
 
 @NgModule({
   imports: [
@@ -42,7 +44,9 @@ import { WorkItemRoutingModule } from './work-item-routing.module';
     TooltipModule,
     WorkItemDetailModule,
     WorkItemRoutingModule,
-    WorkItemQuickAddModule
+    WorkItemQuickAddModule,
+    TreeModule,
+    TreeListModule
   ],
   declarations: [
     AlmArrayFilter,


### PR DESCRIPTION
Tree nodes are not displayed by default. To enable the toggle, the WorkItem object must have a "children" array. Alternatively, the components getChildren function may be used to fetch children as needed. In this scenario, a "hasChildren" boolean property can be added to the WorkItem object to enable the toggle.

Note that this was tested in the master branch first, then ported to the ngx-widgets branch -- screen shots were taken from the master branch -- see PR #949.

Dragging is enabled, but can be restricted using the allowDrop function.

See below for documentation regarding available options.
https://angular2-tree.readme.io/docs/options

See below for full documentation.
https://angular2-tree.readme.io/docs

Tree list with toggle
![alm-tree-list](https://cloud.githubusercontent.com/assets/17481322/22977706/c5ef42e2-f35d-11e6-8a24-ed17322f951e.png)

Tree list without toggle (default)
![alm-list](https://cloud.githubusercontent.com/assets/17481322/22977722/d0a532a0-f35d-11e6-9918-cfdf4287bb6c.png)