### PR TITLE
Moved Patternfly styles to tree list component

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "ngx-fabric8-wit": "6.6.2",
     "ngx-login-client": "0.1.8",
     "ngx-modal": "0.0.29",
-    "ngx-widgets": "0.7.1",
+    "ngx-widgets": "0.8.0",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.0.1",
     "zone.js": "0.7.7"

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -4,7 +4,7 @@
 		<!--[dialog]='dialog'-->
 	<!--&gt;</alm-dialog>-->
 <!--</div>-->
-<div class="list-group-item" (click)="onSelect($event)">
+<div class="workItemList_entry" (click)="onSelect($event)">
 	<!--checkbox to select a WI and move it-->
 	<div class="row-cbh" title="Select the checkbox to move the item.">
 		<input type="checkbox" [checked]="checkedWI" (click)="toggleEntry($event)" />

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.scss
@@ -1,7 +1,7 @@
 @import '../../../../assets/stylesheets/base';
 
-.list-group-item {
-  background-color: transparent;
+.workItemList_entry {
+  display: flex;
   cursor: pointer;
   font-size: rem(12);
   align-items: center;
@@ -20,7 +20,6 @@
   }
 
   &:hover {
-    background-color: transparent;
     .row-cbh {
       border-right: 1px solid $color-pf-black-500;
       input{
@@ -66,36 +65,9 @@ span{
   }
 }
 
-.selected {
-  background-color: $color-pf-blue-100;
-  &:hover {
-    background-color: $color-pf-blue-100;
-  }
-}
 @media (max-width: $screen-md-min){
   .workItemList_title{
     font-size: rem(16);
     padding: 0 !important;
-  }
-}
-
-// Tree list item
-.tree-list-item {
-  display: flex;
-  padding-right: 0;
-  &:hover {
-    background-color: $color-pf-black-200;
-  }
-  &.tree-list-item-selected:hover {
-    background-color: $color-pf-blue-100 !important;
-  }
-}
-
-.tree-list-item-selected {
-  .list-group-item {
-    border: none;
-    &:hover {
-      background-color: $color-pf-blue-100 !important;
-    }
   }
 }

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -11,7 +11,7 @@
         <div class="work-item-list-page flex-container in-column-direction flex-grow-1">
           <div #listContainer
               almInfiniteScroll
-              class="detail-list-wrap list-group list-view-pf"
+              class="detail-list-wrap"
               [eachElementHeightInPx]='contentItemHeight'
               (initItems)='initWiItems($event)'
               (fetchMore)='fetchMoreWiItems()'>
@@ -27,7 +27,6 @@
               <template #treeListTemplate let-node="node" let-index="index">
                 <alm-tree-list-item #treeListItem
                     [node]="node"
-                    (onSelect)="onSelect($event)"
                     [template]="treeListItemTemplate">
                   <template #treeListItemTemplate>
                     <alm-work-item-list-entry

--- a/src/app/work-item/work-item-list/work-item-list.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list.component.scss
@@ -6,6 +6,11 @@
     background-color: transparent;
   }
 }
+
+.tree-list-item {
+  display: flex;
+}
+
 .work-item-list-page {
   >.list-group
   {

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -9,7 +9,8 @@ import {
   ViewChildren,
   QueryList,
   TemplateRef,
-  DoCheck
+  DoCheck,
+  ViewEncapsulation
 } from '@angular/core';
 import {
   Router,
@@ -36,6 +37,7 @@ import { WorkItemService }            from '../work-item.service';
 import { TreeListComponent } from 'ngx-widgets';
 
 @Component({
+  encapsulation: ViewEncapsulation.None,
   host:{
     'class':"app-component flex-container in-column-direction flex-grow-1"
   },


### PR DESCRIPTION
Moved a couple Patternfly styles (list-view-pf, list-group & list-group-item) from the planner UI to the tree list component.

We will want to use these Patternfly styles in other places with the tree list. This means there are far less tree list styles to override in planner and/or elsewhere.
