### PR TITLE
docs(README): Format main readme and split apart contributing.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,136 @@
+[[continuous-delivery-semantic-relases]]
+== Continuous Delivery & Semantic Relases
+
+In fabric8-planner we use the
+https://github.com/semantic-release/semantic-release[semantic-release
+plugin]. That means that all you have to do is use the AngularJS Commit
+Message Conventions (documented below). Once the PR is merged, a new
+release will be automatically published to npmjs.com and a release tag
+created on github. The version will be updated following semantic
+versionning rules.
+
+[[commit-message-format]]
+=== Commit Message Format
+
+A commit message consists of a *header*, *body* and *footer*. The header
+has a *type*, *scope* and *subject*:
+
+....
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+....
+
+The *header* is mandatory and the *scope* of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This
+allows the message to be easier to read on GitHub as well as in various
+git tools.
+
+[[commit-revert]]
+==== Revert
+
+If the commit reverts a previous commit, it should begin with `revert:`,
+followed by the header of the reverted commit. In the body it should
+say: `This reverts commit <hash>.`, where the hash is the SHA of the
+commit being reverted.
+
+[[commit-type]]
+==== Type
+
+If the prefix is `feat`, `fix` or `perf`, it will always appear in the
+changelog.
+
+Other prefixes are up to your discretion. Suggested prefixes are `docs`,
+`chore`, `style`, `refactor`, and `test` for non-changelog related
+tasks.
+
+[[commit-scope]]
+==== Scope
+
+The scope could be anything specifying place of the commit change. For
+example `$location`, `$browser`, `$compile`, `$rootScope`, `ngHref`,
+`ngClick`, `ngView`, etc…
+
+[[commit-subject]]
+==== Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: ``change'' not ``changed'' nor
+``changes''
+* don’t capitalize first letter
+* no dot (.) at the end
+
+[[commit-body]]
+==== Body
+
+Just as in the *subject*, use the imperative, present tense: ``change''
+not ``changed'' nor ``changes''. The body should include the motivation
+for the change and contrast this with previous behavior.
+
+[[commit-footer]]
+==== Footer
+
+The footer should contain any information about *Breaking Changes* and
+is also the place to reference GitHub issues that this commit *Closes*.
+
+*Breaking Changes* should start with the word `BREAKING CHANGE:` with a
+space or two newlines. The rest of the commit message is then used for
+this.
+
+A detailed explanation can be found in this
+https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#[document].
+
+Based on
+https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
+
+[[commit-examples]]
+==== Examples
+
+Appears under ``Features`` header, pencil subheader:
+
+....
+feat(pencil): add 'graphiteWidth' option
+....
+
+Appears under ``Bug Fixes`` header, graphite subheader, with a link to
+issue #28:
+
+....
+fix(graphite): stop graphite breaking when width < 0.1
+
+Closes #28
+....
+
+Appears under ``Performance Improvements`` header, and under ``Breaking
+Changes`` with the breaking change explanation:
+
+....
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
+....
+
+The following commit and commit `667ecc1` do not appear in the changelog
+if they are under the same release. If not, the revert commit appears
+under the ``Reverts`` header.
+
+....
+revert: feat(pencil): add 'graphiteWidth' option
+
+This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
+....
+
+[[commitizen]]
+=== Commitizen: craft valid commit messages
+
+Commitizen helps you craft correct commit messages. Install it using
+`npm install commitizen -g`. Then run `git cz` rather than `git commit`.
+
+[[validate-commit-msg]]
+=== validate-commit-msg
+
+The `validate-commit-msg` githook checks for invalid commit messages.

--- a/README.adoc
+++ b/README.adoc
@@ -1,321 +1,166 @@
 = Fabric8 Planner
 
-image:https://ci.centos.org/buildStatus/icon?job=devtools-fabric8-planner-build-master[Jenkins,link="https://ci.centos.org/view/Devtools/job/devtools-fabric8-planner-build-master/lastBuild/"]
-image:https://ci.centos.org/buildStatus/icon?job=devtools-fabric8-planner-npm-publish-build-master[Jenkins,link="https://ci.centos.org/view/Devtools/job/devtools-fabric8-planner-npm-publish-build-master/lastBuild/"]
-image:https://codecov.io/gh/almighty/almighty-ui/branch/master/graph/badge.svg[Codecov.io,link="https://codecov.io/gh/almighty/almighty-ui"]
+image:https://ci.centos.org/buildStatus/icon?job=devtools-fabric8-planner-build-master[Jenkins, link="https://ci.centos.org/view/Devtools/job/devtools-fabric8-planner-build-master/lastBuild/"]
+image:https://ci.centos.org/buildStatus/icon?job=devtools-fabric8-planner-npm-publish-build-master[Jenkins, link="https://ci.centos.org/view/Devtools/job/devtools-fabric8-planner-npm-publish-build-master/lastBuild/"]
+image:https://codecov.io/gh/almighty/almighty-ui/branch/master/graph/badge.svg[Codecov.io, link="https://codecov.io/gh/almighty/almighty-ui"]
+image:https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic%20release-b4d455.svg[Semantic Release, link="https://github.com/semantic-release/semantic-release"]
 
-=== Fabric8 Planner is a currently an application planner and issue tracker front-end.
-It uses https://github.com/almighty/almighty-core[Fabric8 Work Item Tracker] as the back-end.
+**Fabric8 Planner is a task planner and issue tracker front-end.**
 
-If this is the first time you are starting the UI you need to run
+It uses https://github.com/almighty/almighty-core[Fabric8 Work Item Tracker]
+as the back-end.
 
-----
-$ npm install
-----
+== Running the app
 
-If you trying to refresh your install you can run:
+=== Set NODE_ENV
+If you're just trying to test the application, please use inmemory mode which
+will load the app with mock data for you. If you, however, want to contribute
+to the codebase, unset it back or to "development" (default) mode and rebuild.
 
-----
-$ npm run reinstall
-----
 
-Start the app by executing the following.
+[source,shell]
+```
+$ export NODE_ENV=inmemory # <1>
+$ export NODE_ENV=development # <2>
+$ export NODE_ENV=production # <3>
 
-----
-$ npm start
-----
+<1> In-memory mode for trying-out the app
+<2> Development mode for contributing to the source
+<2> Production mode for deploying the application
+```
 
-If you wish to run the app with the in-memory dataset, you need to set an environment
-variable "ENV" to "inmemory" and do a rebuild. The setting is stored inside the build,
-changing the value back to unset or "development" (default for npm start) needs a rebuild
-to take effect.
+Once you're done setting the environment, you can proceed with the next step(s)
 
-== Run All Checks
+NOTE: If you're directly trying to run the app in dev mode, you can skip this
+step, as *`NODE_ENV`* is treated as `"development"` by default.
+
+IMPORTANT: If you're trying out the app `"inmemory"` mode, then after running
+the app (as explained in the next step) please don't forget to
+http://localhost:8088/?token_json=%7B%22access_token%22%3A%22somerandomtoken%22%2C%22expires_in%22%3A1800%2C%22refresh_expires_in%22%3A1800%2C%22refresh_token%22%3A%22somerandomtoken%22%2C%22token_type%22%3A%22bearer%22%7D[visit this URL]
+to load it up with mock data, including the authenticated/logged-in user.
+
+=== First run
+
+If you're trying to run the app for the first time:
+
+ $ npm install
+
+Then, start the app with:
+
+ $ npm start
+
+=== Fresh run
+
+If you trying to refresh your installation, you need to run:
+
+ $ npm run reinstall
+
+Then, start the app with:
+
+ $ npm start
+
+=== Testcase run
 
 To run the linter, build validator, unit tests, and functional test use:
 
-----
-$ npm test
-----
+ $ npm test
 
+== Other useful scripts
 
-== Lint
+The *`package.json`* file's `scripts:` section lists _all the tasks_ we run.
 
-To run the TypeScript and Angular 2 linter, use:
+Here are some of the most useful/frequently used scripts you may need to run:
 
-----
-$ npm run lint
-----
+[cols="1,2,4", options="header"]
+|===
+|Scipt
+|Command
+|Description
 
-NOTE: They also run during the unit tests.
+|Lint
+|`$ npm run lint`
+|Runs the TypeScript and Angular 2 linter
 
-== Build Validation
+|Validation
+|`$ npm run validate`
+|Validates the webpack build
 
-To validate the webpack build, use:
+|Unit Tests
+|`$ npm run test:unit`
+|Runs the unit tests
 
-----
-$ npm run validate
-----
+|Functional Tests
+|`$ npm run test:func`
+|Runs the functional tests
 
-NOTE: Validation also runs the unit tests.
+|Continuous Tests
+|`$ npm run watch:test`
+|Looks for changes in source code and runs unit tests
+|===
 
-== Unit Tests
+=== CI scripts
 
-To run the unit test, use:
+There are some other scripts for CI-environment; such as `run_unit_tests.sh`,
+`run_functional_tests.sh`, `cico_run_tests.sh`, `cico_build_deploy.sh` etc.
+They're generally not meant to be run manually.
 
-----
-$ npm run test:unit
-----
+== Building the app
 
-To run the unit test in a watch mode so that they are rerun every time you save, use:
+=== Production build
 
-----
-$ npm run watch:test
-----
-
-Unit (UI) tests are automatically executed on the PR(pull request) check process (using
-`cico_run_tests.sh`) or on the release process (using `cico_build_deploy.sh`). To executed
-these scripts from the development environment you can run the following script:
-
-----
-./run_unit_tests.sh
-----
-
-For unit testing, Jasmine, Karma, Webpack is used. There are unit tests available for
-both services and UI components. There are `.spec.ts` files available in individual
-component or service folder. Karma and Webpack config is written inside config directory
-under root.
-
-== Functional Tests
-
-To run the functional test, use:
+To generate production build, set API URL and run build script as follows:
 
 ----
-$ npm run test:func
-----
-
-Functional (UI) tests are automatically executed on the PR check process (using
-`cico_run_tests.sh`) or on the release process (using `cico_build_deploy.sh`) but
-can also be executed from the development environment by invoking the following command:
-
-----
-./run_functional_tests.sh
-----
-
-External resources are mocked. A Java JRE, ncat and fuser have to be available on the
-system (see Dockerfile.builder for details on the required packages when building on
-Fedora/CentOS). PhantomJS will be used as the browser engine by default. This can be
-changed by adding/modifying browser capabilities in `protractor.config.js`.
-
-Test specs for functional tests are residing in `src/tests`.
-
-== Inmemory Mode
-
-To Run project in Inmemory mode, use:
-
-----
-$ NODE_ENV=inmemory npm start
-----
-----
-Browse URL : http://localhost:8088/?token_json=%7B%22access_token%22%3A%22somerandomtoken%22%2C%22expires_in%22%3A1800%2C%22refresh_expires_in%22%3A1800%2C%22refresh_token%22%3A%22somerandomtoken%22%2C%22token_type%22%3A%22bearer%22%7D
-----
-
-In-memory mode allows fabric8-planner to run without needing federated authentication service and fills the app with mock data set. This mode is good for demo and testing purposes.
-
-== Production Build
-
-To generate production build, set the API URL and run `npm` command as give below:
-
-----
-export API_URL="http://api.example.org/api/"
-npm run build:prod
+$ export API_URL="http://api.example.org/api/"
+$ npm run build:prod
 ----
 
 The build output will be under `dist` directory.
 
-To create docker image, run this command immediately after the previous command:
+*To create a docker image,* run this command immediately after the production
+build completion:
 
 ----
-docker build -t almighty-ui-deploy -f Dockerfile.deploy .
+$ docker build -t fabric8-planner-deploy -f Dockerfile.deploy .
 ----
 
-== Library Build
+=== Library Build
 
-=== Production
+==== For production:
 
-To build the Planner as a npm library, use:
+To build the Planner as an npm library, use:
 
 ----
-npm run build
+$ npm run build
 ----
 
-Whilst the standalone build uses webpack the library build uses gulp.
+The created library will be placed in `dist`.
 
-The created library is located in `dist`. You shouldn't ever publish the
-build manually, instead you should let the CD pipeline do a semantic release.
+IMPORTANT: *You shouldn't ever publish the build manually,* instead you should
+let the CD pipeline do a semantic release.
 
-=== Development
+==== For development:
 
-To build  fabric8-planner as an npm library and embed it into a webapp such as
+To build fabric8-planner as an npm library and embed it into a webapp such as
 fabric8-ui, you should:
 
-1. Run `npm run watch:library` in this directory. This will build fabric8-planner as
-a library and then set up a watch task to rebuild any ts, html and scss files you
-change.
-2. In the webapp into which you are embedding, run `npm link <path to fabric8-planner>/dist-watch`.
-This will create a symlink from `node_modules/fabric8-planner` to the `dist-watch` directory
-and install that symlinked node module into your webapp.
-3. Run your webapp in development mode, making sure you have a watch on `node_modules/fabric8-planner`
-enabled. You will have access to both JS sourcemaps and SASS sourcemaps if your webapp
-is properly setup.
+Step 1: Run `npm run watch:library` in the source directory::
+This will build fabric8-planner as a library and then set up a watch task to
+rebuild any ts, html and scss files you change.
 
-Note that `fabric8-ui` is setup to do reloading and sourcemaps automatically when you
+Step 2: Run `npm link <path to fabric8-planner>/dist-watch`::
+In the webapp into which you are embedding. This will create a symlink from
+`node_modules/fabric8-planner` to the `dist-watch` directory and install that
+symlinked node module into your webapp.
+
+Step 3: Run your webapp in development mode::
+Make sure you have a watch on `node_modules/fabric8-planner` enabled. You will
+have access to both JS and SASS sourcemaps if your webapp is properly setup.
+
+NOTE: `fabric8-ui` is setup to do reloading and sourcemaps automatically when you
 run `npm start`.
 
-[[continuous-delivery-semantic-relases]]
-Continuous Delivery & Semantic Relases
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+== Contributing to the app
 
-In fabric8-planner we use the
-https://github.com/semantic-release/semantic-release[semantic-release
-plugin]. That means that all you have to do is use the AngularJS Commit
-Message Conventions (documented below). Once the PR is merged, a new
-release will be automatically published to npmjs.com and a release tag
-created on github. The version will be updated following semantic
-versionning rules.
-
-[[commit-message-format]]
-Commit Message Format
-^^^^^^^^^^^^^^^^^^^^^
-
-A commit message consists of a *header*, *body* and *footer*. The header
-has a *type*, *scope* and *subject*:
-
-....
-<type>(<scope>): <subject>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
-....
-
-The *header* is mandatory and the *scope* of the header is optional.
-
-Any line of the commit message cannot be longer 100 characters! This
-allows the message to be easier to read on GitHub as well as in various
-git tools.
-
-[[revert]]
-Revert
-^^^^^^
-
-If the commit reverts a previous commit, it should begin with `revert:`,
-followed by the header of the reverted commit. In the body it should
-say: `This reverts commit <hash>.`, where the hash is the SHA of the
-commit being reverted.
-
-[[type]]
-Type
-^^^^
-
-If the prefix is `feat`, `fix` or `perf`, it will always appear in the
-changelog.
-
-Other prefixes are up to your discretion. Suggested prefixes are `docs`,
-`chore`, `style`, `refactor`, and `test` for non-changelog related
-tasks.
-
-[[scope]]
-Scope
-^^^^^
-
-The scope could be anything specifying place of the commit change. For
-example `$location`, `$browser`, `$compile`, `$rootScope`, `ngHref`,
-`ngClick`, `ngView`, etc…
-
-[[subject]]
-Subject
-^^^^^^^
-
-The subject contains succinct description of the change:
-
-* use the imperative, present tense: ``change'' not ``changed'' nor
-``changes''
-* don’t capitalize first letter
-* no dot (.) at the end
-
-[[body]]
-Body
-^^^^
-
-Just as in the *subject*, use the imperative, present tense: ``change''
-not ``changed'' nor ``changes''. The body should include the motivation
-for the change and contrast this with previous behavior.
-
-[[footer]]
-Footer
-^^^^^^
-
-The footer should contain any information about *Breaking Changes* and
-is also the place to reference GitHub issues that this commit *Closes*.
-
-*Breaking Changes* should start with the word `BREAKING CHANGE:` with a
-space or two newlines. The rest of the commit message is then used for
-this.
-
-A detailed explanation can be found in this
-https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#[document].
-
-Based on
-https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
-
-[[examples]]
-Examples
-^^^^^^^^
-
-Appears under ``Features'' header, pencil subheader:
-
-....
-feat(pencil): add 'graphiteWidth' option
-....
-
-Appears under ``Bug Fixes'' header, graphite subheader, with a link to
-issue #28:
-
-....
-fix(graphite): stop graphite breaking when width < 0.1
-
-Closes #28
-....
-
-Appears under ``Performance Improvements'' header, and under ``Breaking
-Changes'' with the breaking change explanation:
-
-....
-perf(pencil): remove graphiteWidth option
-
-BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
-....
-
-The following commit and commit `667ecc1` do not appear in the changelog
-if they are under the same release. If not, the revert commit appears
-under the ``Reverts'' header.
-
-....
-revert: feat(pencil): add 'graphiteWidth' option
-
-This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
-....
-
-[[commitizen---craft-valid-commit-messages]]
-Commitizen - craft valid commit messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Commitizen helps you craft correct commit messages. Install it using
-`npm install commitizen -g`. Then run `git cz` rather than `git commit`.
-
-[[validate-commit-msg---validate-commit-messages]]
-Validate-commit-msg - validate commit messages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The validate-commit-msg githook checks for invalid commit messages.
+The development guide is part of the link:./CONTRIBUTING.adoc[contributors'
+instructions]. Please check it out in order to contribute to this project.


### PR DESCRIPTION
Updated the README.adoc and created CONTRIBUTING.adoc
- Better asciidoc formatting
- Rephrasing and cleaning up of contents
- Contribution and commit related doc moved into new contribution guide (to be expanded)