### PR TITLE
Bumped ng2-boostrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lodash": "4.17.4",
     "moment": "2.17.1",
     "mydatepicker": "1.7.2",
-    "ng2-bootstrap": "1.1.16",
+    "ng2-bootstrap": "1.3.3",
     "ng2-completer": "0.3.1",
     "ng2-dnd": "2.0.1",
     "ngx-dropdown": "0.0.22",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,9 +8,8 @@ import { HttpModule, Http }    from '@angular/http';
 import { FormsModule } from '@angular/forms';
 
 import { DropdownModule } from 'ng2-bootstrap';
-import { TabsModule } from 'ng2-bootstrap/components/tabs';
 import { ModalModule } from 'ngx-modal';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TabsModule, TooltipModule } from 'ng2-bootstrap';
 import {
   AuthenticationService,
   Broadcaster,

--- a/src/app/iteration/iteration.component.html
+++ b/src/app/iteration/iteration.component.html
@@ -16,7 +16,7 @@
             <div class="flex-grow-1 truncate">
               <strong class="iteration-name "
                 tooltip="{{iteration.attributes.name}}"
-                tooltipPlacement="top"
+                placement="top"
                 (click)='getWorkItemsByIteration(iteration)'>
                 {{iteration.attributes.name}}
               </strong>
@@ -61,7 +61,7 @@
                 aria-valuemin="0"
                 [attr.aria-valuemax]="iteration.relationships?.workitems?.meta?.total"
                 [ngStyle]="{'width': ((iteration.relationships?.workitems?.meta?.closed / iteration.relationships?.workitems?.meta?.total) * 100) + '%'}"
-                tooltipPlacement="top"
+                placement="top"
                 tooltip="{{((iteration.relationships?.workitems?.meta?.closed / iteration.relationships?.workitems?.meta?.total) * 100) + '%'}}">
             </div>
             <!--<div class="progress-bar progress-bar-remaining"
@@ -70,7 +70,7 @@
                 aria-valuemin="0"
                 aria-valuemax="100"
                 [ngStyle]="{'width': 100 - barchatValue + '%'}"
-                tooltipPlacement="top"
+                placement="top"
                 tooltip="{{(100 - barchatValue) + '%'}}">
             </div>-->
           </div>
@@ -91,7 +91,7 @@
             <a *ngIf="loggedIn && editEnabled"
               class="text-right"
               (click)="modal.openCreateUpdateModal('create');">
-              <i *ngIf="loggedIn && editEnabled" id="add-iteration-icon" class="fa fa-plus-circle fa-lg pull-right with-cursor-pointer" tooltipPlacement="bottom" tooltip="Add an Iteration"></i>
+              <i *ngIf="loggedIn && editEnabled" id="add-iteration-icon" class="fa fa-plus-circle fa-lg pull-right with-cursor-pointer" placement="bottom" tooltip="Add an Iteration"></i>
             </a>
           </small>
         </h4>
@@ -103,7 +103,7 @@
           <div class="flex-grow-1 truncate">
             <strong class="iteration-name"
               tooltip="{{iteration.attributes.name}}"
-              tooltipPlacement="top"
+              placement="top"
               (click)='getWorkItemsByIteration(iteration)'>
               {{iteration.attributes.name}}
             </strong>
@@ -151,7 +151,7 @@
           <div class="truncate flex-grow-1">
             <strong class="iteration-name "
               tooltip="{{iteration.attributes.name}}"
-              tooltipPlacement="top"
+              placement="top"
               (click)='getWorkItemsByIteration(iteration)'>
               {{iteration.attributes.name}}
             </strong>

--- a/src/app/iteration/iteration.module.ts
+++ b/src/app/iteration/iteration.module.ts
@@ -10,7 +10,7 @@ import { MyDatePickerModule } from 'mydatepicker';
 import { IterationComponent } from './iteration.component';
 import { IterationService } from './iteration.service';
 import { ModalModule } from 'ngx-modal';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TooltipModule } from 'ng2-bootstrap';
 
 @NgModule({
   imports: [

--- a/src/app/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/toolbar-panel/toolbar-panel.component.html
@@ -30,7 +30,7 @@
         </span>
       </template>
       <template #add>
-        <div *ngIf="loggedIn && editEnabled" class="with-cursor-pointer" tooltipPlacement="bottom" tooltip="Add A Work Item" (click)="typeSelectPanel.openPanel()">
+        <div *ngIf="loggedIn && editEnabled" class="with-cursor-pointer" placement="bottom" tooltip="Add A Work Item" (click)="typeSelectPanel.openPanel()">
           <i class="pficon pficon-add-circle-o margin-top-4"></i>
         </div>
       </template>

--- a/src/app/toolbar-panel/toolbar-panel.module.ts
+++ b/src/app/toolbar-panel/toolbar-panel.module.ts
@@ -1,8 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ModalModule } from 'ngx-modal';
-import { DropdownModule } from 'ng2-bootstrap';
+import {
+  ComponentLoaderFactory,
+  DropdownConfig,
+  DropdownModule,
+  PositioningService,
+  TooltipConfig
+} from 'ng2-bootstrap';
 
 import { FilterService } from '../shared/filter.service';
 import { WorkItemService } from './../work-item/work-item.service';
@@ -31,6 +36,10 @@ import {
   ],
   providers: [
     FilterService,
+    ComponentLoaderFactory,
+    DropdownConfig,
+    PositioningService,
+    TooltipConfig,
     WorkItemService
   ],
   exports: [ToolbarPanelComponent]

--- a/src/app/type/type.component.html
+++ b/src/app/type/type.component.html
@@ -10,7 +10,7 @@
           <div class="truncate flex-container">
             <strong class="type-name "
               tooltip="User Story"
-              tooltipPlacement="top"
+              placement="top"
               (click)='getWorkItemsByType("userstory")'>
               User Story
             </strong>
@@ -20,7 +20,7 @@
           <div class="truncate flex-container">
             <strong class="type-name "
               tooltip="User Story"
-              tooltipPlacement="top"
+              placement="top"
               (click)='getWorkItemsByType("bug")'>
               Bug
             </strong>

--- a/src/app/type/type.module.ts
+++ b/src/app/type/type.module.ts
@@ -5,7 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { CollapseModule } from 'ng2-bootstrap';
 import { DropdownModule } from 'ng2-bootstrap';
 import { ModalModule } from 'ngx-modal';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TooltipModule } from 'ng2-bootstrap';
 
 import { TypeComponent } from './type.component';
 

--- a/src/app/work-item/work-item-board/planner-board.module.ts
+++ b/src/app/work-item/work-item-board/planner-board.module.ts
@@ -6,7 +6,7 @@ import { DndModule } from 'ng2-dnd';
 import { ModalModule } from 'ngx-modal';
 import { DropdownModule } from 'ng2-bootstrap';
 import { TreeModule } from 'angular2-tree-component';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TooltipModule } from 'ng2-bootstrap';
 import {
   AlmIconModule,
   DialogModule,

--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.html
@@ -25,7 +25,7 @@
             <div class="user-avatar">
                 <img id="{{'comment_avatar_' + counter}}"
                 class="user-assign-avatar pull-left"
-                tooltipPlacement="right"
+                placement="right"
                 tooltip="{{comment.relationalData.creator?.attributes?.fullName}}"
                 *ngIf="comment.relationalData.creator?.attributes?.imageURL"
                 [src]="comment.relationalData.creator?.attributes?.imageURL | almAvatarSize:30"

--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.spec.ts
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.spec.ts
@@ -13,10 +13,16 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
-
-import { DropdownModule } from 'ng2-bootstrap';
+import {
+  ComponentLoaderFactory,
+  DropdownConfig,
+  DropdownModule,
+  PositioningService,
+  TooltipConfig,
+  TooltipModule
+} from 'ng2-bootstrap';
 import { Ng2CompleterModule } from 'ng2-completer';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import {  } from 'ng2-bootstrap';
 import { AlmUserName } from '../../../pipes/alm-user-name.pipe';
 import {
   // AlmUserName,
@@ -49,7 +55,7 @@ import { WorkItemCommentComponent } from './work-item-comment.component';
 import { WorkItemDetailComponent } from '../work-item-detail.component';
 import { WorkItemLinkTypeFilterByTypeName, WorkItemLinkFilterByTypeName } from '../work-item-detail-pipes/work-item-link-filters.pipe';
 
-import { CollapseModule } from 'ng2-bootstrap/components/collapse';
+import { CollapseModule } from 'ng2-bootstrap';
 
 describe('Comment section for the work item detailed view - ', () => {
   let comp: WorkItemDetailComponent;
@@ -398,6 +404,8 @@ describe('Comment section for the work item detailed view - ', () => {
       ],
       providers: [
         Broadcaster,
+        ComponentLoaderFactory,
+        DropdownConfig,
         Logger,
         Location,
         {
@@ -415,7 +423,9 @@ describe('Comment section for the work item detailed view - ', () => {
         {
           provide: WorkItemService,
           useValue: fakeWorkItemService
-        }
+        },
+        PositioningService,
+        TooltipConfig
       ]
     }).compileComponents()
       .then(() => {

--- a/src/app/work-item/work-item-detail/work-item-detail.component.html
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.html
@@ -106,7 +106,7 @@
               *ngIf="workItem.relationalData?.assignees?.length"
               (click)="activeSearchAssignee()"
               class="pull-left user-assign-avatar"
-              tooltipPlacement="bottom"
+              placement="bottom"
               tooltip="{{workItem.relationalData.assignees[0]?.attributes.fullName}}"
               src="{{workItem.relationalData.assignees[0]?.attributes.imageURL + '&s=20'}}"
               onError="this.src='https://avatars0.githubusercontent.com/u/563119?v=3&s=20'" />
@@ -169,7 +169,7 @@
             </span>
             <img *ngIf="workItem.relationalData?.creator"
               class="pull-left user-avatar"
-              tooltipPlacement="bottom"
+              placement="bottom"
               tooltip="{{workItem.relationalData.creator.attributes.fullName}}"
               src="{{workItem.relationalData.creator.attributes.imageURL + '&s=20'}}"
               id="WI_details_reporter_img" />

--- a/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.spec.ts
@@ -14,9 +14,15 @@ import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
 
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
 import { Ng2CompleterModule } from 'ng2-completer';
-import { DropdownModule } from 'ng2-bootstrap';
+import {
+  ComponentLoaderFactory,
+  DropdownConfig,
+  DropdownModule,
+  PositioningService,
+  TooltipConfig,
+  TooltipModule
+} from 'ng2-bootstrap';
 import { AlmUserName } from '../../pipes/alm-user-name.pipe';
 import {
   // AlmUserName,
@@ -47,7 +53,7 @@ import { WorkItemLinkComponent } from './work-item-link/work-item-link.component
 import { WorkItemCommentComponent } from './work-item-comment/work-item-comment.component';
 import { WorkItemDetailComponent } from './work-item-detail.component';
 import { WorkItemLinkTypeFilterByTypeName, WorkItemLinkFilterByTypeName } from './work-item-detail-pipes/work-item-link-filters.pipe';
-import { CollapseModule } from 'ng2-bootstrap/components/collapse';
+import { CollapseModule } from 'ng2-bootstrap';
 
 describe('Detailed view and edit a selected work item - ', () => {
   let comp: WorkItemDetailComponent;
@@ -376,6 +382,8 @@ describe('Detailed view and edit a selected work item - ', () => {
       ],
       providers: [
         Broadcaster,
+        ComponentLoaderFactory,
+        DropdownConfig,
         Logger,
         Location,
         {
@@ -393,7 +401,9 @@ describe('Detailed view and edit a selected work item - ', () => {
         {
           provide: WorkItemService,
           useValue: fakeWorkItemService
-        }
+        },
+        PositioningService,
+        TooltipConfig
       ]
     }).compileComponents()
       .then(() => {

--- a/src/app/work-item/work-item-detail/work-item-detail.module.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.module.ts
@@ -2,8 +2,7 @@ import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule }  from '@angular/forms';
 
-import { CollapseModule } from 'ng2-bootstrap/components/collapse';
-import { TooltipModule }  from 'ng2-bootstrap/components/tooltip';
+import { CollapseModule, TooltipModule } from 'ng2-bootstrap';
 import { Ng2CompleterModule } from 'ng2-completer';
 import { DropdownModule } from 'ng2-bootstrap';
 

--- a/src/app/work-item/work-item-list/planner-list.module.ts
+++ b/src/app/work-item/work-item-list/planner-list.module.ts
@@ -3,10 +3,10 @@ import { CommonModule }     from '@angular/common';
 import { HttpModule, Http } from '@angular/http';
 
 import { DndModule } from 'ng2-dnd';
-import { DropdownModule } from 'ng2-bootstrap';
+import { DropdownModule, TooltipModule } from 'ng2-bootstrap';
 import { ModalModule } from 'ngx-modal';
 import { TreeModule } from 'angular2-tree-component';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+
 import {
   AlmIconModule,
   DialogModule,

--- a/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/work-item/work-item-list/work-item-list-entry/work-item-list-entry.component.html
@@ -31,7 +31,7 @@
   <div class="user-avatar">
       <img
         *ngFor="let wItem of workItem.relationalData.assignees"
-        tooltipPlacement="bottom"
+        placement="bottom"
         tooltip="{{wItem?.attributes?.fullName}}"
         src="{{wItem?.attributes?.imageURL + '&s=23'}}"
         onError="this.src='https://avatars0.githubusercontent.com/u/563119?v=3&s=23'" />

--- a/src/app/work-item/work-item-list/work-item-list.component.spec.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.spec.ts
@@ -16,7 +16,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { CommonModule } from '@angular/common';
 
 import { DndModule } from 'ng2-dnd';
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TooltipModule } from 'ng2-bootstrap';
 import { AlmUserName } from '../../pipes/alm-user-name.pipe';
 import {
   // AlmUserName,

--- a/src/app/work-item/work-item.component.html
+++ b/src/app/work-item/work-item.component.html
@@ -97,7 +97,7 @@
               </div>
               <!-- ADD a Work Item FAB -->
               <div class="toolbar-pf-action-right">
-                <div *ngIf="loggedIn && editEnabled" class="with-cursor-pointer" tooltipPlacement="bottom" tooltip="Add A Work Item" (click)="showTypes()">
+                <div *ngIf="loggedIn && editEnabled" class="with-cursor-pointer" placement="bottom" tooltip="Add A Work Item" (click)="showTypes()">
                   <i class="pficon pficon-add-circle-o margin-top-4"></i>
                 </div>
               </div>

--- a/src/app/work-item/work-item.module.ts
+++ b/src/app/work-item/work-item.module.ts
@@ -1,7 +1,7 @@
 import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { TooltipModule } from 'ng2-bootstrap/components/tooltip';
+import { TooltipModule } from 'ng2-bootstrap';
 import { DndModule } from 'ng2-dnd';
 import { ModalModule } from 'ngx-modal';
 import { DropdownModule } from 'ng2-bootstrap';


### PR DESCRIPTION
Bumping ng2-bootstrap version to be compatible with ngx-widgets. Also renaming deprecated 'tooltipPlacement' attributes as 'placement'.

Note that ngx-widgets is currently generating deprecation warnings for 'tooltipPlacement'. This repo is using the latest version of ng2-bootstrap 1.3.3. In order to fix these deprecations, planner also needs to use the same version. If not, planner's pages will not render when ngx-widgets uses the new placement attribute name.