### PR TITLE
fix(inmemory): Adds areas mock data and service.

### DIFF
--- a/src/app/area/area.service.ts
+++ b/src/app/area/area.service.ts
@@ -53,12 +53,15 @@ export class AreaService {
             return response.json().data as AreaModel[];
           })
           .then((data) => {
-            //If the area has a parent, append it to the area's name
-            data.forEach((area) => {
-              if (area.attributes.parent_path_resolved !== '/'){
-                area.attributes.name = (area.attributes.parent_path_resolved).substring(1) + '/' + area.attributes.name;
-              }
-            });
+            //Need to fix the Area data and service for inmemory mode
+            if (process.env.ENV != 'inmemory') {
+              //If the area has a parent, append it to the area's name
+              data.forEach((area) => {
+                if (area.attributes.parent_path_resolved !== '/'){
+                  area.attributes.name = (area.attributes.parent_path_resolved).substring(1) + '/' + area.attributes.name;
+                }
+              });
+            }
             this.areas = data;
             return this.areas;
           })

--- a/src/app/models/area.model.ts
+++ b/src/app/models/area.model.ts
@@ -31,9 +31,5 @@ export class AreaRelations {
     links: {
       related: string;
     };
-    meta: {
-      closed: number;
-      total: number;
-    };
   };
 }

--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -314,6 +314,12 @@ export class MockDataService {
     return this.spaces;
   }
 
+  //areas
+  public getAllAreas(): any {
+    console.log('Area - ', this.areas);
+    return this.areas;
+  }
+
   // iterations
 
   public getAllIterations(): any {

--- a/src/app/shared/mock-data/area-mock-generator.ts
+++ b/src/app/shared/mock-data/area-mock-generator.ts
@@ -15,7 +15,8 @@ export class AreaMockGenerator {
         'attributes': {
           'description': 'Description for area ' + n,
           'name': 'Area ' + n,
-          'state': 'new'
+          'parent_path': '/',
+          'parent_path_resolved': '/'
         },
         'id': 'area-id' + n,
         'links': {

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -209,6 +209,8 @@ export class MockHttp extends Http {
         case '/iterations':
           var iterations = this.mockDataService.getAllIterations();
           return this.createResponse(url.toString(), 200, 'ok', { data: iterations, 'meta': { 'totalCount': iterations.length} } );
+        case '/areas':
+          return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getAllAreas() );
         case '/source-link-types':
           return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinkTypes() );
         case '/target-link-types':


### PR DESCRIPTION
Added areas as mock data and service.
@sanbornsen @naina-verma 
The area drop down still does not work inmemory mode
Check the file area.service.ts - line 56 
https://github.com/nimishamukherjee/fabric8-planner/blob/c07a18dc0e306e083c2a5cd2cd350d3d894c2cb1/src/app/area/area.service.ts#L56

