### PR TITLE
fix(planner-height): fixes planner work item list height

### DIFF
--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -39,7 +39,7 @@ import { TreeListComponent } from 'ngx-widgets';
 @Component({
   encapsulation: ViewEncapsulation.None,
   host:{
-    'class':"app-component flex-container in-column-direction flex-grow-1"
+    'class':"app-component flex-container in-column-direction flex-grow-1 height-100"
   },
   selector: 'alm-work-item-list',
   templateUrl: './work-item-list.component.html',


### PR DESCRIPTION
This is a workaround that adds height-100 to the list too ensure it fits
the container