### PR TITLE
refactor(detail-page): align detail page to the content

### DIFF
--- a/src/app/toolbar-panel/toolbar-panel.component.scss
+++ b/src/app/toolbar-panel/toolbar-panel.component.scss
@@ -2,6 +2,7 @@
 
 .toolbar-header {
   padding: 0 rem(20);
+  border-bottom: 1px solid $color-pf-black-300;
 }
 
 .toolbar-pf-action-right {

--- a/src/app/work-item/work-item-board/work-item-board.component.html
+++ b/src/app/work-item/work-item-board/work-item-board.component.html
@@ -7,8 +7,8 @@
     </aside>
     <section>
       <toolbar-panel context="boardview"></toolbar-panel>
-      <div class="contents">
-        <div id="board_topWorkItems" class="container-fluid flex-container flex-grow-1 in-column-direction boardWrapper">
+      <div class="contents posRel">
+        <div id="board_topWorkItems" class="flex-container flex-grow-1 in-column-direction boardWrapper">
           <div class="board">
             <!-- board columns -->
             <div class="board-lane" *ngFor='let lane of lanes'>
@@ -68,8 +68,8 @@
             </div>
           </div>
         </div>
+        <router-outlet></router-outlet>
       </div>
-      <router-outlet></router-outlet>
     </section>
   </main>
 </div>

--- a/src/app/work-item/work-item-board/work-item-board.component.scss
+++ b/src/app/work-item/work-item-board/work-item-board.component.scss
@@ -13,10 +13,10 @@
     right: 0;
     bottom: 0;
     left: 0;
-    padding-bottom: em(10);
+    padding: rem(10) 0;
     .board-lane {
-      width: em(300);
-      margin: 0 em(5);
+      width: rem(300);
+      margin: 0 rem(5);
       height: 100%;
       display: inline-block;
       vertical-align: top;
@@ -28,15 +28,15 @@
         height: 100%;
         padding-bottom: 0;
         .boardlaneWrapper{
-          padding: em(0) em(15);
+          padding: em(0) rem(15);
           overflow: auto;
           width: $width100;
-          height: calc( 100% - 2.5em );
+          height: calc( 100% - 2.5rem );
           .board-card {
             @include Border(1px, solid , $color-pf-black-400);
             background: $color-pf-white;
-            padding: em(15);
-            margin: em(5) 0;
+            padding: rem(15);
+            margin: rem(5) 0;
             >div {
               p {
                 margin: 0;

--- a/src/app/work-item/work-item-detail/work-item-detail.component.scss
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.scss
@@ -244,22 +244,22 @@
   .start-coding {
     display: flex;
     justify-content: flex-end;
-    padding: 0 20px;
+    padding: 0 rem(20);
   }
 }
 
 //detail panel
 .detail-panel {
   background: $color-pf-white;
-  position: fixed;
+  position: absolute;
   left: auto;
-  top: em(34);
+  top: 0;
   right: 0;
   bottom: 0;
-  width: 50%;
-  min-width: em(250);
+  width: 60%;
+  min-width: rem(300);
   z-index: 100;
-  padding: em(20) 0;
+  padding: rem(20) 0;
   border-left: 1px solid darken($color-pf-white, 20%);
   overflow-y: scroll;
 }

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -7,7 +7,7 @@
     </aside>
     <section>
       <toolbar-panel context="listview"></toolbar-panel>
-      <div class="contents">
+      <div class="contents posRel">
         <div class="work-item-list-page flex-container in-column-direction flex-grow-1">
           <div #listContainer
               almInfiniteScroll
@@ -68,8 +68,8 @@
               <alm-work-item-quick-add [wilistview]="'wi-list-view'" (close)="close($event)"></alm-work-item-quick-add>
           </div>
         </div>
+        <router-outlet></router-outlet>
       </div>
-      <router-outlet></router-outlet>
     </section>
   </main>
 </div>

--- a/src/assets/stylesheets/shared/main.scss
+++ b/src/assets/stylesheets/shared/main.scss
@@ -44,6 +44,10 @@ body {
     text-align: $textCenter;
 }
 
+.posRel {
+  position: relative;
+}
+
 @media (max-width: $grid-float-breakpoint) {
     .mobdn {
         display: none;


### PR DESCRIPTION
Fix the position of Detail page relative to the content

<img width="1440" alt="screen shot 2017-03-16 at 2 28 34 pm" src="https://cloud.githubusercontent.com/assets/10396359/23988586/dbe0d9d6-0a54-11e7-97be-78dfc3085a05.png">


Closes: #1156 