### PR TITLE
fix(version): ngx-base as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "ng2-bootstrap": "1.3.3",
     "ng2-completer": "0.3.1",
     "ng2-dragula": "1.3.0",
+    "ngx-base": "1.2.0",
     "ngx-dropdown": "0.0.22",
     "ngx-fabric8-wit": "6.15.2",
     "ngx-login-client": "0.6.5",


### PR DESCRIPTION
We don't rely on versions brought in through ngx-login-client
or ngx-fabric8-wit.