### PR TITLE
fix(comments-wrapping): fix word-wrapping in comments

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.scss
+++ b/src/app/work-item/work-item-detail/work-item-comment/work-item-comment.component.scss
@@ -79,6 +79,7 @@
         -moz-box-shadow: none;
         box-shadow: none;
         height: auto;
+        word-break: break-word;
         &:hover {
           border-color: $color-pf-blue-200;
         }


### PR DESCRIPTION
fix long words in comments field

<img width="709" alt="screen shot 2017-04-03 at 1 51 41 pm" src="https://cloud.githubusercontent.com/assets/10396359/24600980/c14776e2-1874-11e7-995a-a9a5e330f087.png">
<img width="710" alt="screen shot 2017-04-03 at 1 51 58 pm" src="https://cloud.githubusercontent.com/assets/10396359/24600981/c14cf13a-1874-11e7-949e-4cc862a758d4.png">


closes: #1324
