### PR TITLE
feat(sidepanel): update for visual designs of side panel

### DIFF
--- a/src/app/iteration/iteration.component.html
+++ b/src/app/iteration/iteration.component.html
@@ -3,12 +3,12 @@
   <div class="iteration-wrapper">
     <div class="iterations">
       <div class="iteration-header pointer">
-        <h4>
+        <h3>
           <span (click)="isCollapsedIteration = !isCollapsedIteration">
             <i class="fa fa-icon"></i>
             Current Iteration
           </span>
-        </h4>
+        </h3>
       </div>
       <ul class="iteration-expanded-div" [collapse]="isCollapsedCurrentIteration">
         <li class="active" *ngFor="let iteration of currentIterations" (click)='getWorkItemsByIteration(iteration)' [ngClass]="{'selected-iteration': (selectedIteration && selectedIteration.id === iteration.id)}">
@@ -20,7 +20,9 @@
                 {{iteration.attributes.name}}
               </strong>
               <div class="parent-iteration">
-                {{iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}}
+                <span>
+                  {{iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}}
+                </span>
               </div>
             </div>
             <div *ngIf="loggedIn" class="dropdown-kebab-pf" dropdown>
@@ -29,7 +31,7 @@
                       aria-haspopup="true"
                       aria-expanded="true"
                       dropdownToggle>
-                <span class="fa fa-ellipsis-v"></span>
+                <i class="fa fa-ellipsis-v"></i>
               </button>
               <ul class="dropdown-menu-right" dropdownMenu>
                 <li>
@@ -78,7 +80,7 @@
     </div>
     <div class="iterations">
       <div class="iteration-header pointer">
-        <h4>
+        <h3>
           <span (click)="isCollapsedFutureIteration = !isCollapsedFutureIteration">
             <i class="fa fa-icon"
                 [ngClass]="{'fa-angle-right': isCollapsedFutureIteration,
@@ -89,10 +91,10 @@
             <a *ngIf="loggedIn && editEnabled"
               class="text-right"
               (click)="modal.openCreateUpdateModal('create');">
-              <i *ngIf="loggedIn && editEnabled" id="add-iteration-icon" class="pficon-add-circle-o fa-lg pull-right with-cursor-pointer" placement="bottom" tooltip="Add an Iteration"></i>
+              <i *ngIf="loggedIn && editEnabled" id="add-iteration-icon" class="pficon-add-circle-o fa-lg pull-right with-cursor-pointer add-btn" placement="bottom" tooltip="Add an Iteration"></i>
             </a>
           </small>
-        </h4>
+        </h3>
       </div>
       <ul class="not-current-iteration"
           [collapse]="isCollapsedFutureIteration">
@@ -116,7 +118,7 @@
                       aria-haspopup="true"
                       aria-expanded="true"
                       dropdownToggle>
-                <span class="fa fa-ellipsis-v"></span>
+                <i class="fa fa-ellipsis-v"></i>
               </button>
               <ul class="dropdown-menu-right" dropdownMenu>
                 <li>
@@ -143,12 +145,12 @@
     <div class="iterations">
       <div class="iteration-header pointer"
         (click)="isCollapsedPastIteration = !isCollapsedPastIteration">
-        <h4>
+        <h3>
           <i class="fa fa-icon"
               [ngClass]="{'fa-angle-right': isCollapsedPastIteration,
                           'fa-angle-down': !isCollapsedPastIteration}"></i>
           Past Iterations
-        </h4>
+        </h3>
       </div>
       <ul class="not-current-iteration"
           [collapse]="isCollapsedPastIteration">
@@ -159,7 +161,11 @@
               placement="top">
               {{iteration.attributes.name}}
             </strong>
-            <div class="parent-iteration">{{iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}}</div>
+            <div class="parent-iteration">
+              <span>
+                {{iteration.attributes.resolved_parent_path + '/' + iteration.attributes.name}}
+              </span>
+            </div>
           </div>
           <div>
             <span class="badge">{{iteration.relationships?.workitems?.meta?.total}}</span>
@@ -169,7 +175,7 @@
                       aria-haspopup="true"
                       aria-expanded="true"
                       dropdownToggle>
-                <span class="fa fa-ellipsis-v"></span>
+                <i class="fa fa-ellipsis-v"></i>
               </button>
               <ul class="dropdown-menu-right" dropdownMenu>
                 <li>

--- a/src/app/iteration/iteration.component.scss
+++ b/src/app/iteration/iteration.component.scss
@@ -9,18 +9,31 @@
   }
 
 .iterations-container {
-
+  background-color: $color-pf-black-900;
   li {
     cursor: pointer;
   }
-
+  .badge {
+    background-color: $color-pf-black;
+  }
   .selected-iteration {
-    background-color: #bee1f4 !important;
+    background-color: $color-pf-black-700 !important;
+    color: $color-pf-white;
+    border-left: 4px solid $color-pf-blue;
+    i {
+      color: $color-pf-white !important;
+    }
   }
 
   /* Iterations expanded div styling */
   .iteration-wrapper {
-
+    color: $color-pf-white;
+    i {
+      color: $color-pf-white;
+    }
+    .add-btn {
+      color: $color-pf-blue;
+    }
     .iteration-header {
       padding: em(10) em(20);
       > h4 {
@@ -36,12 +49,19 @@
       margin-bottom: 0;
 
       > li {
-        background-color: $color-pf-white;
         list-style: none;
         padding: em(15);
 
         &.active {
-          border-left: 4px solid $navbar-pf-border-color;
+          border-left: 4px solid transparent;
+          &.selected-iteration {
+            border-left: 4px solid $color-pf-blue;
+            .iteration-description {
+              // &:after {
+                @include multiline-truncate($line-height: 1.5em, $line-count: 2, $bg-color: $color-pf-white);
+              // }
+            }          
+          }
         }
 
         .iteration-subheader {
@@ -65,9 +85,8 @@
         .iteration-status {
           padding: em(20) 0 em(15) 0;
         }
-
         .iteration-description {
-          @include multiline-truncate($line-height: 1.5em, $line-count: 2, $bg-color: $color-pf-white) ;
+          @include multiline-truncate($line-height: 1.5em, $line-count: 2, $bg-color: $color-pf-black-700);
         }
       }
     }

--- a/src/app/side-panel/side-panel.component.scss
+++ b/src/app/side-panel/side-panel.component.scss
@@ -4,10 +4,10 @@
   cursor: pointer;
   border: none;
   padding: 0 $grid-gutter-width/2;
-  margin: 0;
-  border-top: 1px solid $color-pf-black-200;
-  border-bottom: 1px solid $color-pf-black-400;
-  background-color: $color-pf-black-200;
+  background-color: $color-pf-black-900;
+  border-bottom: 1px solid $color-pf-black-700;
+  border-left: 4px solid transparent;
+  color: $color-pf-white;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -17,6 +17,12 @@
   }
 
   &.backlog-selected {
-    background: #bee1f4 !important;
+    background-color: $color-pf-black-700;
+    color: $color-pf-white;
+    border-left: 4px solid $color-pf-blue;
+  }
+  
+  .badge {
+    background-color: $color-pf-black;
   }
 }

--- a/src/app/work-item/work-item-board/work-item-board.component.html
+++ b/src/app/work-item/work-item-board/work-item-board.component.html
@@ -3,7 +3,7 @@
     <aside>
       <div class="contents">
         <side-panel
-          [iterations]="iterations">
+          [iterations]="iterations" class="side-panel-container">
         </side-panel>
       </div>
     </aside>

--- a/src/app/work-item/work-item-board/work-item-board.component.scss
+++ b/src/app/work-item/work-item-board/work-item-board.component.scss
@@ -78,12 +78,17 @@
       height: 100%;
     }
   }
-
+.side-panel-container {
+    background-color: $color-pf-black-900;
+}
 .work-item-page {
   display: flex;
   flex: 1;
   flex-direction: column;
   position: relative;
+  > main {
+      border-top: 0 solid !important;
+  }
   .container-modal {
     border: solid 0 red;
     background-color: $color-pf-black-100;

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -3,7 +3,7 @@
     <aside>
       <div class="contents">
         <side-panel
-          [iterations]="iterations">
+          [iterations]="iterations" class="side-panel-container">
         </side-panel>
       </div>
     </aside>

--- a/src/app/work-item/work-item-list/work-item-list.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list.component.scss
@@ -17,7 +17,9 @@
   display: flex;
   align-items: inherit;
 }
-
+.side-panel-container {
+    background-color: $color-pf-black-900;
+}
 .work-item-list-page {
   >.list-group
   {
@@ -59,6 +61,9 @@
     flex: 1;
     flex-direction: column;
     position: relative;
+    > main {
+        border-top: 0 solid !important;
+    }
     .container-modal {
         border: solid 0 red;
         background-color: $color-pf-black-100;

--- a/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
+++ b/src/assets/stylesheets/shared/_overrides-for-patternfly.scss
@@ -15,3 +15,23 @@ $font-size-base: 14px;
 .form-control, .btn, .dropdown-menu, .badge {
   font-size: $font-size-base;
 }
+h1 {
+  font-size: 2em;
+  line-height: 1.3em;
+}
+h2 {
+  font-size: 1.5em;
+  line-height: 1.3em;
+}
+h3 {
+  font-size: 1.3em;
+  line-height: 1.3em;
+}
+h4 {
+  font-size: 1.2em;
+  line-height: 1.3em;
+}
+h5 {
+  font-size: 1.1em;
+  line-height: 1.3em;
+} 


### PR DESCRIPTION
Update the side panel to match the new visual design scheme. This is one part of the overall design upgrade. There will be additional PRs for the navigation (in fabric8-ui), Detail Panel and primary buttons.

**NOTE: The 'Collapse Panel' in the visual designs is not, and should not be, implemented**

visual design here: [Planner-HolisticView](https://redhat.invisionapp.com/share/N7B74T4MH#/226261730_A-0400)

screenshots:
<img width="421" alt="screen shot 2017-04-06 at 11 39 22 am" src="https://cloud.githubusercontent.com/assets/4032718/24762892/bc1b99e6-1abd-11e7-9afd-ea75c021e8d8.png">

<img width="372" alt="screen shot 2017-04-06 at 12 29 29 pm" src="https://cloud.githubusercontent.com/assets/4032718/24765160/bd3a8c0e-1ac4-11e7-81f9-5edf92dc096e.png">

