### PR TITLE
Show "selection" for selected board-view item.

### DIFF
--- a/src/app/work-item/work-item-board/work-item-board.component.html
+++ b/src/app/work-item/work-item-board/work-item-board.component.html
@@ -34,7 +34,7 @@
                     </div>
                   </div>
                   <div [dragula]='"first-bag"' class="card-wrapper">
-                    <div class="board-card flex-container in-column-direction flex-grow-1 card-pf card-pf-view card-pf-view-select card-pf-view-single-select" [class.board-card-selected]="isSelected(item)" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
+                    <div class="board-card card-pf card-pf-view card-pf-view-select card-pf-view-single-select" [class.active]="isSelected(item)" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
                          (mousedown)="getWI(item)" (touchstart)="getWI(item)">
                       <div class="row-wrapper">
                         <div class="">

--- a/src/app/work-item/work-item-board/work-item-board.component.html
+++ b/src/app/work-item/work-item-board/work-item-board.component.html
@@ -34,7 +34,7 @@
                     </div>
                   </div>
                   <div [dragula]='"first-bag"' class="card-wrapper">
-                    <div class="board-card flex-container in-column-direction flex-grow-1" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
+                    <div class="board-card flex-container in-column-direction flex-grow-1" [class.board-card-selected]="isSelected(item)" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
                          (mousedown)="getWI(item)" (touchstart)="getWI(item)">
                       <div class="row-wrapper">
                         <div class="">

--- a/src/app/work-item/work-item-board/work-item-board.component.html
+++ b/src/app/work-item/work-item-board/work-item-board.component.html
@@ -34,7 +34,7 @@
                     </div>
                   </div>
                   <div [dragula]='"first-bag"' class="card-wrapper">
-                    <div class="board-card flex-container in-column-direction flex-grow-1" [class.board-card-selected]="isSelected(item)" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
+                    <div class="board-card flex-container in-column-direction flex-grow-1 card-pf card-pf-view card-pf-view-select card-pf-view-single-select" [class.board-card-selected]="isSelected(item)" *ngFor='let item of lane.workItems' routerLink="./detail/{{item.id}}" [attr.data-id]="item.id"
                          (mousedown)="getWI(item)" (touchstart)="getWI(item)">
                       <div class="row-wrapper">
                         <div class="">

--- a/src/app/work-item/work-item-board/work-item-board.component.scss
+++ b/src/app/work-item/work-item-board/work-item-board.component.scss
@@ -1,4 +1,5 @@
 @import '../../../assets/stylesheets/base';
+@import '../../../assets/stylesheets/shared/layout';
 @import '../../../assets/stylesheets/dragula';
 
 .boardWrapper {
@@ -37,6 +38,13 @@
             background: $color-pf-white;
             padding: rem(15);
             margin: rem(5) 0;
+            @extend .flex-container;
+            @extend .in-column-direction;
+            @extend .flex-grow-1;
+            &.active {
+              border: 2px solid $color-pf-blue-300;
+              box-shadow: none;
+            }
             >div {
               p {
                 margin: 0;
@@ -57,9 +65,6 @@
               justify-content: space-between;
             }
           }//boardcard ended
-          .board-card-selected {
-            border: 2px solid $color-pf-blue-300;
-          }
         }//boardlaneWrapper ended
         .lane-header {
           text-align: $textCenter;

--- a/src/app/work-item/work-item-board/work-item-board.component.scss
+++ b/src/app/work-item/work-item-board/work-item-board.component.scss
@@ -58,7 +58,7 @@
             }
           }//boardcard ended
           .board-card-selected {
-            border: 3px solid #bee1f4;
+            border: 2px solid $color-pf-blue-300;
           }
         }//boardlaneWrapper ended
         .lane-header {

--- a/src/app/work-item/work-item-board/work-item-board.component.scss
+++ b/src/app/work-item/work-item-board/work-item-board.component.scss
@@ -57,6 +57,9 @@
               justify-content: space-between;
             }
           }//boardcard ended
+          .board-card-selected {
+            border: 3px solid #bee1f4;
+          }
         }//boardlaneWrapper ended
         .lane-header {
           text-align: $textCenter;

--- a/src/app/work-item/work-item-board/work-item-board.component.ts
+++ b/src/app/work-item/work-item-board/work-item-board.component.ts
@@ -242,6 +242,10 @@ export class WorkItemBoardComponent implements OnInit, OnDestroy {
     this.workItem = _workItem;
   }
 
+  isSelected(wi: WorkItem){
+    return this.workItem == wi;
+  }
+
   onDrop(args) {
     let [el, target, source, sibling] = args;
     target.parentElement.parentElement.classList.remove('active-lane');


### PR DESCRIPTION
Fixes #1303  #1271 

@nimishamukherjee @sanbornsen @vikram-raj I have added css property for `selected item` in board view.
I would like to confirm the `color=#bee1f4` and `border width=3px`. (Hence WIP :smile: )
Also, when I close the item detail pop over, the WI box still remains selected. I found this same in list view too.

[Issue](https://github.com/fabric8io/fabric8-planner/issues/1554) created for de-selection on close of deatil-box. 