### PR TITLE
Fix iterations, Part 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@angular/platform-browser-dynamic": "4.0.1",
     "@angular/platform-server": "4.0.1",
     "@angular/router": "4.0.1",
-    "angular-tree-component": "3.2.4",
+    "angular-tree-component": "3.2.3",
     "core-js": "2.4.1",
     "lodash": "4.17.4",
     "moment": "2.18.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -79,10 +79,11 @@ if (process.env.ENV == 'inmemory') {
     serviceImports,
     SpacesService,
     ssoApiUrlProvider,
+    MockHttp,
     DummySpace,
     {
       provide: HttpServiceLGC,
-      useClass: MockHttp
+      useExisting: MockHttp
     }
   ];
 } else {

--- a/src/app/iteration/iteration-modal/iteration-modal.component.ts
+++ b/src/app/iteration/iteration-modal/iteration-modal.component.ts
@@ -361,6 +361,7 @@ export class FabPlannerIterationModalComponent implements OnInit, OnDestroy, OnC
       } else {
         this.validationError = true;
       }
+      console.log(this.iteration);
     }
 
     removeError() {

--- a/src/app/iteration/iteration.component.html
+++ b/src/app/iteration/iteration.component.html
@@ -82,7 +82,7 @@
       <div class="iteration-header pointer">
         <h3>
           <span (click)="isCollapsedFutureIteration = !isCollapsedFutureIteration">
-            <i class="fa fa-icon"
+            <i class="fa fa-icon pointer"
                 [ngClass]="{'fa-angle-right': isCollapsedFutureIteration,
                           'fa-angle-down': !isCollapsedFutureIteration}"></i>
             Future Iterations
@@ -146,7 +146,7 @@
       <div class="iteration-header pointer"
         (click)="isCollapsedPastIteration = !isCollapsedPastIteration">
         <h3>
-          <i class="fa fa-icon"
+          <i class="fa fa-icon pointer"
               [ngClass]="{'fa-angle-right': isCollapsedPastIteration,
                           'fa-angle-down': !isCollapsedPastIteration}"></i>
           Past Iterations

--- a/src/app/iteration/iteration.component.html
+++ b/src/app/iteration/iteration.component.html
@@ -54,7 +54,7 @@
           </div>
           <div class="iteration-status display-flex">
             <div class="flex-1">
-              <span>{{iteration.attributes.startAt | date:longDate}} - {{iteration.attributes.endAt | date:longDate}}</span>
+              <span><span *ngIf="iteration.attributes.startAt">{{iteration.attributes.startAt | date:longDate}} - {{iteration.attributes.endAt | date:longDate}}</span>&nbsp;</span>
               <span class="iteration-count">
                 <strong>
                   {{iteration.relationships?.workitems?.meta?.closed}} of {{iteration.relationships?.workitems?.meta?.total}}

--- a/src/app/iteration/iteration.component.scss
+++ b/src/app/iteration/iteration.component.scss
@@ -35,6 +35,9 @@
       color: $color-pf-blue;
     }
     .iteration-header {
+      .pointer {
+        cursor: pointer;
+      }
       padding: em(10) em(20);
       > h4 {
         margin: 0;

--- a/src/app/iteration/iteration.component.ts
+++ b/src/app/iteration/iteration.component.ts
@@ -169,7 +169,6 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
     this.iterationService.getIterations().first().subscribe((updatedIterations:IterationModel[]) => {
       // updating the counts from the response. May not the best solution on performance right now.
       updatedIterations.forEach((thisIteration:IterationModel) => {
-        console.log(thisIteration);
         for (let i=0; i<this.iterations.length; i++) {
           if (this.iterations[i].id === thisIteration.id) {
             this.iterations[i].relationships.workitems.meta.total = thisIteration.relationships.workitems.meta.total;

--- a/src/app/iteration/iteration.component.ts
+++ b/src/app/iteration/iteration.component.ts
@@ -87,13 +87,24 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
 
   getAndfilterIterations() {
     if (this.takeFromInput) {
-      this.allIterations = this.iterations;
+      // do not display the root iteration on the iteration panel.
+      for (let i=0; i<this.iterations.length; i++) {
+        if (!this.iterationService.isRootIteration(this.iterations[i])) {
+          this.allIterations.push(this.iterations[i]);
+        }
+      }
       this.clusterIterations();
     } else {
       this.iterationService.getIterations()
       .subscribe((iterations) => {
-          this.allIterations = iterations;
-          this.clusterIterations();
+        this.allIterations = [];
+        // do not display the root iteration on the iteration panel.
+        for (let i=0; i<iterations.length; i++) {
+          if (!this.iterationService.isRootIteration(iterations[i])) {
+            this.allIterations.push(iterations[i]);
+          }
+        }
+        this.clusterIterations();
       },
       (e) => {
         console.log('Some error has occured', e);
@@ -152,6 +163,7 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
     this.iterationService.getIterations().first().subscribe((updatedIterations:IterationModel[]) => {
       // updating the counts from the response. May not the best solution on performance right now.
       updatedIterations.forEach((thisIteration:IterationModel) => {
+        console.log(thisIteration);
         for (let i=0; i<this.iterations.length; i++) {
           if (this.iterations[i].id === thisIteration.id) {
             this.iterations[i].relationships.workitems.meta.total = thisIteration.relationships.workitems.meta.total;

--- a/src/app/iteration/iteration.component.ts
+++ b/src/app/iteration/iteration.component.ts
@@ -59,7 +59,6 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
     this.spaceSubscription = this.spaces.current.subscribe(space => {
       if (space) {
         console.log('[IterationComponent] New Space selected: ' + space.attributes.name);
-        console.log(space);
         this.editEnabled = true;
         this.getAndfilterIterations();
       } else {
@@ -75,7 +74,13 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges() {
     if (this.takeFromInput) {
-      this.allIterations = this.iterations;
+      // do not display the root iteration on the iteration panel.
+      this.allIterations = [];
+      for (let i=0; i<this.iterations.length; i++) {
+        if (!this.iterationService.isRootIteration(this.iterations[i])) {
+          this.allIterations.push(this.iterations[i]);
+        }
+      }
       this.clusterIterations();
     }
   }
@@ -88,6 +93,7 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
   getAndfilterIterations() {
     if (this.takeFromInput) {
       // do not display the root iteration on the iteration panel.
+      this.allIterations = [];
       for (let i=0; i<this.iterations.length; i++) {
         if (!this.iterationService.isRootIteration(this.iterations[i])) {
           this.allIterations.push(this.iterations[i]);
@@ -96,19 +102,19 @@ export class IterationComponent implements OnInit, OnDestroy, OnChanges {
       this.clusterIterations();
     } else {
       this.iterationService.getIterations()
-      .subscribe((iterations) => {
-        this.allIterations = [];
-        // do not display the root iteration on the iteration panel.
-        for (let i=0; i<iterations.length; i++) {
-          if (!this.iterationService.isRootIteration(iterations[i])) {
-            this.allIterations.push(iterations[i]);
+        .subscribe((iterations) => {
+          // do not display the root iteration on the iteration panel.
+          this.allIterations = [];
+          for (let i=0; i<iterations.length; i++) {
+            if (!this.iterationService.isRootIteration(iterations[i])) {
+              this.allIterations.push(iterations[i]);
+            }
           }
-        }
-        this.clusterIterations();
-      },
-      (e) => {
-        console.log('Some error has occured', e);
-      });
+          this.clusterIterations();
+        },
+        (e) => {
+          console.log('Some error has occured', e);
+        });
     }
   }
 

--- a/src/app/iteration/iteration.service.ts
+++ b/src/app/iteration/iteration.service.ts
@@ -156,6 +156,15 @@ export class IterationService {
       });
   }
 
+  getRootIteration(): Observable<IterationModel> {
+    return this.getIterations().first().map((resultIterations:IterationModel[]) => {
+      for (let i=0; i<resultIterations.length; i++) {
+        if (resultIterations[i].attributes.parent_path==='/')
+          return resultIterations[i];
+      }
+    });
+  }
+
   getIteration(iteration: any): Observable<IterationModel> {
     if (Object.keys(iteration).length) {
       let iterationLink = iteration.data.links.self;
@@ -164,6 +173,13 @@ export class IterationService {
     } else {
       return Observable.of(iteration);
     }
+  }
+
+  getWorkItemCountInIteration(iteration: any): Observable<number> {
+    return this.getIteration({ data: iteration }).first().map((resultIteration:IterationModel) => {
+      console.log(resultIteration);
+      return resultIteration.relationships.workitems.meta.total;
+    });
   }
 
   /**

--- a/src/app/iteration/iterations.service.spec.ts
+++ b/src/app/iteration/iterations.service.spec.ts
@@ -17,6 +17,8 @@ import { Broadcaster, Logger} from 'ngx-base';
 import { Spaces } from 'ngx-fabric8-wit';
 import { AuthenticationService } from 'ngx-login-client';
 
+import { MockHttp } from '../shared/mock-http';
+import { HttpService } from '../shared/http-service';
 import { SpacesService } from '../shared/standalone/spaces.service';
 import { IterationModel } from '../models/iteration.model';
 import { IterationService } from './iteration.service';
@@ -67,8 +69,9 @@ describe('Iteration service - ', () => {
         Logger,
         BaseRequestOptions,
         MockBackend,
+        MockHttp,
         {
-          provide: Http,
+          provide: HttpService,
           useFactory: (backend: MockBackend,
             options: BaseRequestOptions) => new Http(backend, options),
           deps: [MockBackend, BaseRequestOptions]

--- a/src/app/models/iteration.model.ts
+++ b/src/app/models/iteration.model.ts
@@ -21,7 +21,7 @@ export class IterationLinks {
 }
 
 export class IterationRelations {
-  parent: {
+  parent?: {
     data: {
       id: string,
       type: string

--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -383,7 +383,6 @@ export class MockDataService {
 
   //areas
   public getAllAreas(): any {
-    console.log('Area - ', this.areas);
     return this.areas;
   }
 

--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -241,13 +241,14 @@ export class MockDataService {
   };
 
   public updateWorkItem(workItem: any): any {
+    console.log(workItem);
     var localWorkItem = cloneDeep(workItem);
     for (var i = 0; i < this.workItems.length; i++) {
       if (this.workItems[i].id === localWorkItem.id) {
         // Some relationship update
         if (workItem.relationships) {
           // Iteration update
-          if (workItem.relationships.iteration.data) {
+          if (workItem.relationships.iteration && workItem.relationships.iteration.data) {
             console.log('WorkItem has updated iteration field: ' + this.workItems[i].id + ' old: ' + JSON.stringify(workItem.relationships.iteration.data) + ' new: ' + JSON.stringify(workItem.relationships.iteration.data));
             this.workItems[i].relationships.iteration = { data: {
               id: workItem.relationships.iteration.data.id,

--- a/src/app/shared/mock-data/iteration-mock-generator.ts
+++ b/src/app/shared/mock-data/iteration-mock-generator.ts
@@ -5,19 +5,55 @@
 export class IterationMockGenerator {
 
   /*
-   * Creates an array of 5 mock iterations with IDs 'iteration-id0' to 'iteration-id25'.
-   * Other data structures in the mock generator rely on the id naming,
-   * creating a consistent mock data. Keep in mind when changing this code.
+   * Creates an array of 5 mock iterations plus parent with IDs 'iteration-id0' to 
+   * 'iteration-id25'. Other data structures in the mock generator rely on the 
+   * id naming, creating a consistent mock data. Keep in mind when changing 
+   * this code.
    */
   public createIterations(): any {
-    let iterations = [0, 1, 2, 3, 4, 5].map((n) => {
-      return {
+    let iterations: any[] = [];
+    iterations.push({
+        'attributes': {
+          'description': 'Parent Iteration Description',
+          'name': 'Parent Iteration',
+          'state': 'new',
+          'parent_path': '/',
+          'resolved_parent_path': '/'
+        },
+        'id': 'parent-id',
+        'links': {
+          'self': 'http://mock.service/api/iterations/parent-id'
+        },
+        'relationships': {
+          'space': {
+            'data': {
+              'id': 'space-id0',
+              'type': 'spaces'
+            },
+            'links': {
+              'self': 'http://mock.service/api/spaces/space-id0'
+            }
+          },
+          'workitems': {
+            'links': {
+              'related': 'http://mock.service/api/workitems'
+            },
+            'meta': {
+              'total' : 0,
+              'closed' : 0
+            }
+          }
+        },
+        'type': 'iterations'
+    });
+    for (let n=0; n<5; n++) {
+      iterations.push({
         'attributes': {
           'description': 'Description for iteration ' + n,
           'name': 'Iteration ' + n,
           'state': 'new',
-          'parent_path': '',
-          'resolved_parent_path': ''
+          'parent_path': '/parent-id',
+          'resolved_parent_path': '/Parent Iteration'
         },
         'id': 'iteration-id' + n,
         'links': {
@@ -53,8 +89,8 @@ export class IterationMockGenerator {
           }
         },
         'type': 'iterations'
-      };
-    });
+      });
+    }
     return iterations;
   }
 }

--- a/src/app/shared/mock-data/iteration-mock-generator.ts
+++ b/src/app/shared/mock-data/iteration-mock-generator.ts
@@ -14,15 +14,15 @@ export class IterationMockGenerator {
     let iterations: any[] = [];
     iterations.push({
         'attributes': {
-          'description': 'Parent Iteration Description',
-          'name': 'Parent Iteration',
+          'description': 'Root Iteration Description',
+          'name': 'Root Iteration',
           'state': 'new',
           'parent_path': '/',
           'resolved_parent_path': '/'
         },
-        'id': 'parent-id',
+        'id': 'root-iteration-id',
         'links': {
-          'self': 'http://mock.service/api/iterations/parent-id'
+          'self': 'http://mock.service/api/iterations/root-iteration-id'
         },
         'relationships': {
           'space': {
@@ -52,8 +52,8 @@ export class IterationMockGenerator {
           'description': 'Description for iteration ' + n,
           'name': 'Iteration ' + n,
           'state': 'new',
-          'parent_path': '/parent-id',
-          'resolved_parent_path': '/Parent Iteration'
+          'parent_path': '/root-iteration-id',
+          'resolved_parent_path': '/Root Iteration'
         },
         'id': 'iteration-id' + n,
         'links': {

--- a/src/app/shared/mock-data/work-item-mock-generator.ts
+++ b/src/app/shared/mock-data/work-item-mock-generator.ts
@@ -147,7 +147,7 @@ export class WorkItemMockGenerator {
         },
         'relationships': {
           'assignees': { },
-          'iteration': { },
+          'iteration': (n % 2)? { } : { 'data': { 'id': 'iteration-id0', 'links': { 'self': 'http://mock.service/api/iterations/iteration-id0' }, 'type': 'iterations' } },
           'area': { },
           'baseType': {
             'data': {

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -59,13 +59,14 @@ export class MockHttp extends HttpService {
           params[item[0]] = decodeURIComponent(item[1]);
         }
       });
-      // cut off first path element
+      // cut off first path element      
       var result = {
         path: a['pathname'].replace(/^\/[^\/]+\//, '/'),
         host: a['host'],
         port: a['port'],
         params: params
       };
+        
       // parse extra paths based on resource
       if (result.path.indexOf('/workitems/') == 0) {
         result['extraPath'] = result.path.replace(/^\/workitems\//, '');
@@ -79,27 +80,24 @@ export class MockHttp extends HttpService {
         result['extraPath'] = result.path.replace(/^\/workitemtypes\//, '');
         result['path'] = '/workitemtypes';
       }
-
       if (result.path.indexOf('/user/') == 0) {
         result['extraPath'] = result.path.replace(/^\/user\//, '');
         result['path'] = '/user';
       }
-
       if (result.path.indexOf('/iterations/') == 0) {
         result['extraPath'] = result.path.replace(/^\/iterations\//, '');
         result['path'] = '/iterations';
       }
-
       if (result.path.indexOf('/areas/') == 0) {
         result['extraPath'] = result.path.replace(/^\/areas\//, '');
         result['path'] = '/areas';
       }
-
       // if request hat a /space prefix, note the space id, the re-parse the extra path
+      console.log(result.path);
       if (result.path.indexOf('/spaces/') == 0) {
         console.log('Space prefix detected, reparsing url..');
         var spaceId = result.path.split('/')[2];
-        var newUrlBase = 'http://mock.service/api/' + result.path.replace(/^\/spaces\/[^\/]+\//, '');
+        var newUrlBase = url.replace(/\/spaces\/[^\/]+\//, '/');
         console.log('Reparsing with url ' + newUrlBase);
         // Recurse to parse sub-path
         var newResult = this.parseURL(newUrlBase);
@@ -184,7 +182,7 @@ export class MockHttp extends HttpService {
         this.logger.error('GET request failed with request url ' + url);
         return this.createResponse(url.toString(), 500, 'error', {});
       }
-      this.logger.log('GET request at ' + path.path + ' url=' + url.toString() + ' params=' + path.params.toString());
+      this.logger.log('GET request at ' + path.path + ' url=' + url.toString() + ' params=' + JSON.stringify(path.params));
       if (path.extraPath) {
         this.logger.log ('GET request with extraPath at ' + path.extraPath + ' url= ' + url.toString() + ' params=' + path.params.toString());
       }

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -31,12 +31,15 @@ export class MockHttp extends HttpService {
     private WorkItemRegex = /workitems\/(.*)/g;
     private WorkItemSearchRegexp = /work-item-list\/\?name=(.*)/g;
 
+    private selfId;
     private mockDataService: MockDataService;
 
     constructor(private logger: Logger) {
       super(null, null, null);
       let injector = ReflectiveInjector.resolveAndCreate([MockDataService]);
       this.mockDataService = injector.get(MockDataService);
+      this.selfId = this.mockDataService.createId();
+      this.logger.log('Started MockHttp service instance ' + this.selfId);
     };
 
     /*

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -349,7 +349,6 @@ export class MockHttp extends HttpService {
         return this.createResponse(url.toString(), 500, 'error', {});
       }
       if (path.path === '/workitems' && path.extraPath) {
-        console.log('############## - 0');
         if (path.extraPath === 'reorder') {
           var result = JSON.parse(body).data;
         } else {

--- a/src/app/work-item/work-item-board/planner-board.module.ts
+++ b/src/app/work-item/work-item-board/planner-board.module.ts
@@ -50,7 +50,7 @@ if (process.env.ENV == 'inmemory') {
     Logger,
     {
       provide: HttpService,
-      useClass: MockHttp
+      useExisting: MockHttp
     }
   ];
 } else {

--- a/src/app/work-item/work-item-detail/work-item-detail.module.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.module.ts
@@ -35,7 +35,7 @@ import { WorkItemTypeControlService } from '../work-item-type-control.service';
 let providers = [];
 
 if (process.env.ENV == 'inmemory') {
-  providers = [ AreaService, WorkItemTypeControlService, { provide: Http, useClass: MockHttp } ];
+  providers = [ AreaService, WorkItemTypeControlService, { provide: Http, useExisting: MockHttp } ];
 } else {
   providers = [ AreaService, WorkItemTypeControlService ];
 }

--- a/src/app/work-item/work-item-list/planner-list.module.ts
+++ b/src/app/work-item/work-item-list/planner-list.module.ts
@@ -50,7 +50,7 @@ if (process.env.ENV == 'inmemory') {
     Logger,
     {
       provide: HttpService,
-      useClass: MockHttp
+      useExisting: MockHttp
     }
   ];
 } else {

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -117,8 +117,8 @@ export class WorkItemListComponent implements OnInit, AfterViewInit, DoCheck, On
     this.spaceSubscription = this.spaces.current.subscribe(space => {
       if (space) {
         console.log('[WorkItemListComponent] New Space selected: ' + space.attributes.name);
-        this.loadWorkItems();
         this.workItemService.resetWorkItemList();
+        this.loadWorkItems();
       } else {
         console.log('[WorkItemListComponent] Space deselected');
         this.workItems = [];

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -62,6 +62,8 @@ export class WorkItemService {
   private iterations: IterationModel[] = [];
   public _currentSpace;
 
+  private selfId;
+
   constructor(private http: HttpService,
     private broadcaster: Broadcaster,
     private logger: Logger,
@@ -76,6 +78,17 @@ export class WorkItemService {
     if (this.auth.getToken() != null) {
       this.headers.set('Authorization', 'Bearer ' + this.auth.getToken());
     }
+    this.selfId = this.createId();
+    this.logger.log('Launching WorkItemService instance id ' + this.selfId);
+  }
+
+  createId(): string {
+    let id = '';
+    let possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 5; i++)
+      id += possible.charAt(Math.floor(Math.random() * possible.length));
+    console.log('Created new id ' + id);
+    return id;
   }
 
   // switchSpace(space: Space) {
@@ -672,26 +685,9 @@ export class WorkItemService {
    * @param: WorkItem - workItem (Item to be created)
    */
   update(workItem: WorkItem): Observable<WorkItem> {
-    console.log('UPDATEääääääää');
-    console.log(workItem);
-    let oldIterationId: string;
-    if (workItem.relationships && workItem.relationships.iteration &&  workItem.relationships.iteration.data)
-      oldIterationId = workItem.relationships.iteration.data.id;
-    console.log('UPDATEääääääää2');
     return this.http
       .patch(workItem.links.self, JSON.stringify({data: workItem}), { headers: this.headers })
       .map(response => {
-    console.log('UPDATEääääääää3');
-        if (oldIterationId && response.json().relationships.iteration.data && oldIterationId!=response.json().relationships.iteration.data.id) {
-          this.logger.log('################## Iteration has been updated, reloading counts on iteration panel.');
-          this.broadcaster.broadcast('associate_iteration', {
-            workItemId: response.json().id,
-            currentIterationId: oldIterationId,
-            futureIterationId: response.json().relationships.iteration.data.id
-          });
-        }
-            console.log('UPDATEääääääää4');
-
         return response.json().data;
       });
       // .catch ((e) => {

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -672,9 +672,26 @@ export class WorkItemService {
    * @param: WorkItem - workItem (Item to be created)
    */
   update(workItem: WorkItem): Observable<WorkItem> {
+    console.log('UPDATEääääääää');
+    console.log(workItem);
+    let oldIterationId: string;
+    if (workItem.relationships && workItem.relationships.iteration &&  workItem.relationships.iteration.data)
+      oldIterationId = workItem.relationships.iteration.data.id;
+    console.log('UPDATEääääääää2');
     return this.http
       .patch(workItem.links.self, JSON.stringify({data: workItem}), { headers: this.headers })
       .map(response => {
+    console.log('UPDATEääääääää3');
+        if (oldIterationId && response.json().relationships.iteration.data && oldIterationId!=response.json().relationships.iteration.data.id) {
+          this.logger.log('################## Iteration has been updated, reloading counts on iteration panel.');
+          this.broadcaster.broadcast('associate_iteration', {
+            workItemId: response.json().id,
+            currentIterationId: oldIterationId,
+            futureIterationId: response.json().relationships.iteration.data.id
+          });
+        }
+            console.log('UPDATEääääääää4');
+
         return response.json().data;
       });
       // .catch ((e) => {


### PR DESCRIPTION
Fixes several more issues in the iterations panel:
- when the iteration on a work item changes, the counts on the iteration panel are updated.
- the root iteration is no longer displayed in the iteration list.
- several severe bug fixes in the mock data service(s).
- the date display is not visible when no dates are set (no lone "-" display on the current iteration in that case).

This also fixes some other things:
- the list is now updated correctly when selecting a new iteration (only in list view, in board view, this is still broken).
- fixes some other mock related problems.
