### PR TITLE
fix(treelist): Downgraded angular-tree-component for stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@angular/platform-browser-dynamic": "4.0.1",
     "@angular/platform-server": "4.0.1",
     "@angular/router": "4.0.1",
-    "angular-tree-component": "3.2.3",
+    "angular2-tree-component": "2.7.0",
     "core-js": "2.4.1",
     "lodash": "4.17.4",
     "moment": "2.18.1",
@@ -119,7 +119,7 @@
     "ngx-fabric8-wit": "6.17.0",
     "ngx-login-client": "0.6.21",
     "ngx-modal": "0.0.29",
-    "ngx-widgets": "0.13.2",
+    "ngx-widgets": "0.13.4",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.2.0",
     "zone.js": "0.8.5"

--- a/src/app/work-item/work-item-board/planner-board.module.ts
+++ b/src/app/work-item/work-item-board/planner-board.module.ts
@@ -10,7 +10,7 @@ import {
 import { ModalModule } from 'ngx-modal';
 import { DragulaModule } from 'ng2-dragula';
 import { DropdownModule } from 'ng2-bootstrap';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import { TooltipModule } from 'ng2-bootstrap';
 import { Broadcaster, Logger } from 'ngx-base';
 import {

--- a/src/app/work-item/work-item-list/planner-list.module.ts
+++ b/src/app/work-item/work-item-list/planner-list.module.ts
@@ -10,7 +10,7 @@ import {
 
 import { DropdownModule, TooltipModule } from 'ng2-bootstrap';
 import { ModalModule } from 'ngx-modal';
-import { TreeModule } from 'angular-tree-component';
+import { TreeModule } from 'angular2-tree-component';
 import {
   AlmIconModule,
   DialogModule,

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -21,7 +21,7 @@ import {
   ActivatedRoute
 } from '@angular/router';
 
-import { TreeNode } from 'angular-tree-component';
+import { TreeNode } from 'angular2-tree-component';
 
 import { cloneDeep } from 'lodash';
 import { Broadcaster, Logger } from 'ngx-base';


### PR DESCRIPTION
Downgrading angular-tree-component to 2.7.0 to avoid recent issues with the Angular 4 upgrade.

PRs for platform and runtime:
https://github.com/fabric8io/fabric8-ui/pull/675
https://github.com/fabric8-ui/fabric8-runtime-console/pull/274