### PR TITLE
fix(sidepanel): add hover state to sidepanel headers

### DIFF
--- a/src/app/iteration/iteration.component.scss
+++ b/src/app/iteration/iteration.component.scss
@@ -54,7 +54,9 @@
       > li {
         list-style: none;
         padding: em(15);
-
+        &:hover {
+          background-color: $color-pf-black-700;
+        }
         &.active {
           border-left: 4px solid transparent;
           &.selected-iteration {
@@ -63,7 +65,7 @@
               // &:after {
                 @include multiline-truncate($line-height: 1.5em, $line-count: 2, $bg-color: $color-pf-white);
               // }
-            }          
+            }
           }
         }
 
@@ -105,6 +107,9 @@
 
       > li {
         padding: em(5) em(15) em(5) em(40);
+        &:hover {
+          background-color: $color-pf-black-700;
+        }
         .iteration-name{
             line-height: 1.5rem;
           }

--- a/src/app/side-panel/side-panel.component.scss
+++ b/src/app/side-panel/side-panel.component.scss
@@ -11,6 +11,9 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  &:hover {
+    background-color: $color-pf-black-700;
+  }
 
   h3 {
     margin-bottom: em(15);
@@ -21,7 +24,7 @@
     color: $color-pf-white;
     border-left: 4px solid $color-pf-blue;
   }
-  
+
   .badge {
     background-color: $color-pf-black;
   }


### PR DESCRIPTION
add a hover state to the sidepanel headers to signify that they are clickable

resolves https://github.com/fabric8io/fabric8-ux/issues/389

All tests run locally and passed
![screen shot 2017-04-13 at 2 32 54 pm](https://cloud.githubusercontent.com/assets/4032718/25018744/1f240a4e-2056-11e7-8994-ea483f420932.png)
