### PR TITLE
fix(create new work item): Add a few keyboard short cuts for navigation and selection.

### DIFF
--- a/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.html
+++ b/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.html
@@ -1,13 +1,14 @@
-<div *ngIf="panelState === 'in'" class="row container-modal container-cards-pf">
+<div *ngIf="panelState === 'in'" class="row container-modal container-cards-pf" (keyup)="keyboardSelect($event)">
   <div class="row row-cards-pf">
     <div class="col-xs-12 container-modal-header ">
       <h2 class="header-text margin-0">Choose a new work item type</h2>
       <i class="header-text pficon pficon-close" (click)="close()"></i>
     </div>
   </div>
-  <div class="row row-cards-pf">
+  <div class="row row-cards-pf" #typeList>
     <div *ngFor="let type of workItemTypes" class="col-xs-12 col-sm-6 col-md-4 col-lg-3" (click)="select(type)">
-      <div class="card-pf card-pf-view card-pf-view-select">
+      <div class="card-pf card-pf-view card-pf-view-select"
+      [class.card-pf-accented] = "selectedType.id===type.id">
         <div class="card-pf-body">
           <div class="card-pf-top-element">
             <i class="card-pf-icon-circle fa {{type.attributes.icon}}"></i>

--- a/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
+++ b/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
@@ -89,6 +89,9 @@ export class WorkItemDetailAddTypeSelectorWidgetComponent implements OnInit {
         case 13://enter
           this.select(this.selectedType);
         break
+        case 27://esc
+          this.close();
+        break;
         default:
         //check for starting letter of work item type
         let char = String.fromCharCode(event.keyCode);

--- a/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
+++ b/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
@@ -64,96 +64,41 @@ export class WorkItemDetailAddTypeSelectorWidgetComponent implements OnInit {
 
   @HostListener('window:keydown', ['$event'])
   onKeyEvent(event: any) {
-    let list = this.typeList.nativeElement.children;
-    let witLength = this.workItemTypes.length;
-    switch(event.keyCode){
-      case 40://down
-      case 37://left
-        //left or down - go to the previous work item type
-        this.selectedPosition--;
-        if(this.selectedPosition <= 0 ) {
-          this.selectedPosition = 0
-        }
+    if(this.panelState === 'in') {
+      let list = this.typeList.nativeElement.children;
+      let witLength = this.workItemTypes.length;
+      switch(event.keyCode){
+        case 40://down
+        case 37://left
+          //left or down - go to the previous work item type
+          this.selectedPosition--;
+          if(this.selectedPosition <= 0 ) {
+            this.selectedPosition = 0
+          }
+          this.selectedType = this.workItemTypes[this.selectedPosition];
+        break;
+        case 38://top
+        case 39://right
+          //top or right - go to the next work item type
+          this.selectedPosition++;
+          if(this.selectedPosition >= witLength) {
+            this.selectedPosition = witLength - 1;
+          }
+          this.selectedType = this.workItemTypes[this.selectedPosition];
+        break;
+        case 13://enter
+          this.select(this.selectedType);
+        break
+        default:
+        //check for starting letter of work item type
+        let char = String.fromCharCode(event.keyCode);
+        this.workItemTypes.filter( (item,index) => {
+          if((item.attributes.name).charAt(0).toLocaleLowerCase() === char.toLocaleLowerCase())
+            this.selectedPosition = index;
+        });
         this.selectedType = this.workItemTypes[this.selectedPosition];
-      break;
-      case 38://top
-      case 39://right
-        //top or right - go to the next work item type
-        this.selectedPosition++;
-        if(this.selectedPosition >= witLength) {
-          this.selectedPosition = witLength - 1;
-        }
-        this.selectedType = this.workItemTypes[this.selectedPosition];
-      break;
-      case 13://enter
-        this.select(this.selectedType);
-      break
-      // default:
-      //   //check for starting letter of work item type
-      //var x = event.keyCode;                // Get the Unicode value
-      //var y = String.fromCharCode(x);
-      // break;
+        break;
+      }
     }
-    console.log('event.keyCode', event.keyCode);
-  }
-
-  keyboardSelect(event) {
-    //Starting letters to select
-    //Arrow navigation
-    //If type is selected, hit enter to go to the detail view
-    //this.log.log(event.keyCode);
-    console.log('hello34', event.keyCode);
-    // Down arrow or up arrow
-    //typeList
-    // // Down arrow or up arrow
-    // if (event.keyCode == 40 || event.keyCode == 38) {
-    //   let lis = this.areaList.nativeElement.children;
-    //   let i = 0;
-    //   for (; i < lis.length; i++) {
-    //     if (lis[i].classList.contains('selected')) {
-    //       break;
-    //     }
-    //   }
-    //   if (i == lis.length) { // No existing selected
-    //     if (event.keyCode == 40) { // Down arrow
-    //       lis[0].classList.add('selected');
-    //       lis[0].scrollIntoView(false);
-    //     } else { // Up arrow
-    //       lis[lis.length - 1].classList.add('selected');
-    //       lis[lis.length - 1].scrollIntoView(false);
-    //     }
-    //   } else { // Existing selected
-    //     lis[i].classList.remove('selected');
-    //     if (event.keyCode == 40) { // Down arrow
-    //       lis[(i + 1) % lis.length].classList.add('selected');
-    //       lis[(i + 1) % lis.length].scrollIntoView(false);
-    //     } else { // Down arrow
-    //       // In javascript mod gives exact mod for negative value
-    //       // For example, -1 % 6 = -1 but I need, -1 % 6 = 5
-    //       // To get the round positive value I am adding the divisor
-    //       // with the negative dividend
-    //       lis[(((i - 1) % lis.length) + lis.length) % lis.length].classList.add('selected');
-    //       lis[(((i - 1) % lis.length) + lis.length) % lis.length].scrollIntoView(false);
-    //     }
-    //   }
-    // } else if (event.keyCode == 13) { // Enter key event
-    //   let lis = this.areaList.nativeElement.children;
-    //   let i = 0;
-    //   for (; i < lis.length; i++) {
-    //     if (lis[i].classList.contains('selected')) {
-    //       break;
-    //     }
-    //   }
-    //   if (i < lis.length) {
-    //     let selectedId = lis[i].dataset.value;
-    //     this.selectedArea = lis[i];
-    //     this.setArea();
-    //   }
-    // } else {
-    //   let inp = this.areaSearch.nativeElement.value.trim();
-    //   this.filteredAreas = this.areas.filter((item) => {
-    //      return item.attributes.name.toLowerCase().indexOf(inp.toLowerCase()) > -1;
-    //   });
-    // }
   }
 }

--- a/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
+++ b/src/app/work-item/work-item-detail-add-type-selector/work-item-detail-add-type-selector-widget/work-item-detail-add-type-selector-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, OnChanges, EventEmitter, Output } from '@angular/core';
+import { Component, HostListener, OnInit, Input, OnChanges, EventEmitter, Output, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute, NavigationExtras } from '@angular/router';
 
 import { cloneDeep } from 'lodash';
@@ -27,7 +27,12 @@ export class WorkItemDetailAddTypeSelectorWidgetComponent implements OnInit {
   @Output('onSelect') onSelect = new EventEmitter();
   @Output('onClose') onClose = new EventEmitter();
 
+  @ViewChild('typeList') typeList: any;
+
+
   panelState: string = 'out';
+  selectedType: WorkItemType;
+  selectedPosition: number = 0;
 
   constructor(
     private router: Router,
@@ -48,10 +53,107 @@ export class WorkItemDetailAddTypeSelectorWidgetComponent implements OnInit {
 
   open() {
     this.panelState = 'in';
+    this.selectedType = this.workItemTypes[0];
+    this.selectedPosition = 0;
   }
 
   select(type: WorkItemType) {
     this.onSelect.emit(type);
     this.panelState = 'out';
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  onKeyEvent(event: any) {
+    let list = this.typeList.nativeElement.children;
+    let witLength = this.workItemTypes.length;
+    switch(event.keyCode){
+      case 40://down
+      case 37://left
+        //left or down - go to the previous work item type
+        this.selectedPosition--;
+        if(this.selectedPosition <= 0 ) {
+          this.selectedPosition = 0
+        }
+        this.selectedType = this.workItemTypes[this.selectedPosition];
+      break;
+      case 38://top
+      case 39://right
+        //top or right - go to the next work item type
+        this.selectedPosition++;
+        if(this.selectedPosition >= witLength) {
+          this.selectedPosition = witLength - 1;
+        }
+        this.selectedType = this.workItemTypes[this.selectedPosition];
+      break;
+      case 13://enter
+        this.select(this.selectedType);
+      break
+      // default:
+      //   //check for starting letter of work item type
+      //var x = event.keyCode;                // Get the Unicode value
+      //var y = String.fromCharCode(x);
+      // break;
+    }
+    console.log('event.keyCode', event.keyCode);
+  }
+
+  keyboardSelect(event) {
+    //Starting letters to select
+    //Arrow navigation
+    //If type is selected, hit enter to go to the detail view
+    //this.log.log(event.keyCode);
+    console.log('hello34', event.keyCode);
+    // Down arrow or up arrow
+    //typeList
+    // // Down arrow or up arrow
+    // if (event.keyCode == 40 || event.keyCode == 38) {
+    //   let lis = this.areaList.nativeElement.children;
+    //   let i = 0;
+    //   for (; i < lis.length; i++) {
+    //     if (lis[i].classList.contains('selected')) {
+    //       break;
+    //     }
+    //   }
+    //   if (i == lis.length) { // No existing selected
+    //     if (event.keyCode == 40) { // Down arrow
+    //       lis[0].classList.add('selected');
+    //       lis[0].scrollIntoView(false);
+    //     } else { // Up arrow
+    //       lis[lis.length - 1].classList.add('selected');
+    //       lis[lis.length - 1].scrollIntoView(false);
+    //     }
+    //   } else { // Existing selected
+    //     lis[i].classList.remove('selected');
+    //     if (event.keyCode == 40) { // Down arrow
+    //       lis[(i + 1) % lis.length].classList.add('selected');
+    //       lis[(i + 1) % lis.length].scrollIntoView(false);
+    //     } else { // Down arrow
+    //       // In javascript mod gives exact mod for negative value
+    //       // For example, -1 % 6 = -1 but I need, -1 % 6 = 5
+    //       // To get the round positive value I am adding the divisor
+    //       // with the negative dividend
+    //       lis[(((i - 1) % lis.length) + lis.length) % lis.length].classList.add('selected');
+    //       lis[(((i - 1) % lis.length) + lis.length) % lis.length].scrollIntoView(false);
+    //     }
+    //   }
+    // } else if (event.keyCode == 13) { // Enter key event
+    //   let lis = this.areaList.nativeElement.children;
+    //   let i = 0;
+    //   for (; i < lis.length; i++) {
+    //     if (lis[i].classList.contains('selected')) {
+    //       break;
+    //     }
+    //   }
+    //   if (i < lis.length) {
+    //     let selectedId = lis[i].dataset.value;
+    //     this.selectedArea = lis[i];
+    //     this.setArea();
+    //   }
+    // } else {
+    //   let inp = this.areaSearch.nativeElement.value.trim();
+    //   this.filteredAreas = this.areas.filter((item) => {
+    //      return item.attributes.name.toLowerCase().indexOf(inp.toLowerCase()) > -1;
+    //   });
+    // }
   }
 }


### PR DESCRIPTION
Use keyboard keys to navigate and select a work item. 
- Left or down to go to the previous work item type
- Top or right to go to the next work item type
- Enter to select a work item type
- Select a work item type using the starting letter of the work item type

To fix - if there are two or more work items with the same starting letter, the same work item, in descending alphabetical order, would get selected each time the letter is pressed.