### PR TITLE
Search WI within selected space (while linking the item).

### DIFF
--- a/src/app/shared/http-service.ts
+++ b/src/app/shared/http-service.ts
@@ -46,7 +46,7 @@ export class HttpService extends Http {
     console.log('GET request initiated');
     console.log('URL - ', url);
     console.log('Options - ', options);
-    return super.get(url, { headers: this.headers });
+    return super.get(url, { headers: this.headers, search:options });
   }
 
   post(url: string, body: any, options: RequestOptionsArgs = {}) {

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -947,10 +947,15 @@ export class WorkItemService {
   searchLinkWorkItem(term: string, workItemType: string): Observable<WorkItem[]> {
     if (this._currentSpace) {
       // FIXME: make the URL great again (when we know the right API URL for this)!
-      let searchUrl = this.baseApiUrl + 'search?q=' + term + ' type:' + workItemType;
+      // search within selected space
+      let params = {
+        'spaceID': this._currentSpace.id,
+        'q' : term + ' type:' + workItemType
+      }
+      let searchUrl = this.baseApiUrl + 'search'
       //let searchUrl = currentSpace.links.self + 'search?q=' + term + ' type:' + workItemType;
       return this.http
-          .get(searchUrl)
+          .get(searchUrl, params)
           .map((response) => response.json().data as WorkItem[])
           // .catch ((e) => {
           //   if (e.status === 401) {

--- a/src/app/work-item/work-item.service.ts
+++ b/src/app/work-item/work-item.service.ts
@@ -948,14 +948,14 @@ export class WorkItemService {
     if (this._currentSpace) {
       // FIXME: make the URL great again (when we know the right API URL for this)!
       // search within selected space
-      let params = {
+      let queryParams = {
         'spaceID': this._currentSpace.id,
         'q' : term + ' type:' + workItemType
       }
       let searchUrl = this.baseApiUrl + 'search'
       //let searchUrl = currentSpace.links.self + 'search?q=' + term + ' type:' + workItemType;
       return this.http
-          .get(searchUrl, params)
+          .get(searchUrl, queryParams)
           .map((response) => response.json().data as WorkItem[])
           // .catch ((e) => {
           //   if (e.status === 401) {


### PR DESCRIPTION
fixes #1604 

Earlier we used to search across spaces but now selected space will be considered for searching.

New URL will look like - `http://localhost:8080/api/search?spaceID=52e7929d-879c-4936-974f-0cd7cc0aa5cc&q=log%20type:86af5178-9b41-469b-9096-57e5155c3f31` 
note the `spaceID` in the query params.


Backend still support searching across all spaces. Do not pass `spaceID` to search across all spaces.
Backend related [task](https://github.com/almighty/almighty-core/pull/1184) is already merged in master.