### PR TITLE
fix(board): fix alignment of type selector

### DIFF
--- a/src/app/toolbar-panel/toolbar-panel.component.scss
+++ b/src/app/toolbar-panel/toolbar-panel.component.scss
@@ -24,3 +24,8 @@
 .currently-showing {
   margin-right: 10px;
 }
+.board-type-dropdown {
+  .dropdown-menu {
+    right: 0;
+  }
+}


### PR DESCRIPTION
fix the alignment of the type selector dropdown to justify to the right of the button