### PR TITLE
fix(detail): Detail page bug fixed

### DIFF
--- a/src/app/work-item/work-item-detail/work-item-detail.component.ts
+++ b/src/app/work-item/work-item-detail/work-item-detail.component.ts
@@ -138,37 +138,32 @@ export class WorkItemDetailComponent implements OnInit, AfterViewInit, OnDestroy
     this.getIterations();
     this.loggedIn = this.auth.isLoggedIn();
     let id = null;
-    this.route.params.forEach((params: Params) => {
-      if (params['id'] !== undefined) {
-        id = params['id'];
 
-        if (id.indexOf('new') >= 0){
-          //Add a new work item
-          this.addNewWI = true;
-          this.headerEditable = true;
-          let type = this.route.queryParams.forEach(params => {
-            this.createWorkItemObj(params['type']);
-          });
-
-          // Open the panel
-          if (this.panelState === 'out') {
-            this.panelState = 'in';
-            if (this.headerEditable && typeof(this.title) !== 'undefined') {
-              this.title.nativeElement.focus();
+    this.eventListeners.push(
+      this.spaces.current.switchMap(space => {
+        return this.route.params;
+      }).subscribe((params) => {
+        if (params['id'] !== undefined) {
+          id = params['id'];
+          if (id === 'new'){
+            //Add a new work item
+            this.headerEditable = true;
+            let type = this.route.snapshot.queryParams['type'];
+            // Create new item with the WI type
+            this.createWorkItemObj(type);
+            // Open the panel
+            if (this.panelState === 'out') {
+              this.panelState = 'in';
+              if (this.headerEditable && typeof(this.title) !== 'undefined') {
+                this.title.nativeElement.focus();
+              }
             }
+          } else {
+            this.loadWorkItem(id);
           }
-        } else {
-          this.loadWorkItem(id);
         }
-      }
-    });
-    this.spaceSubscription = this.spaces.current.subscribe(space => {
-      if (space) {
-        // this.getAreas();
-        // this.getIterations();
-        this.loadWorkItem(id);
-      }
-    });
+      })
+    );
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
### Problem
After creating new item with details page, navigating to any iteration from back log is making the new created item's details page blank.

### How to reproduce
* Stay on backlog
* Detail add an item
* Wait for opening the details page of newly created item
* Switch to an iteration
* URL looks good but the details page is going blank as it is for creating a new item.

### Solution 
* Remove incorrect use of **route.queryParams** observable and use **route.snapshot** instead.
* Use the advantage of **switchMap** to queue up the to observable i.e. **currentSpace** and then **route.params**