### PR TITLE
Tree only displays no-parent items now; with toggle between that and flat mode

### DIFF
--- a/src/app/shared/mock-data.service.ts
+++ b/src/app/shared/mock-data.service.ts
@@ -97,12 +97,14 @@ export class MockDataService {
     let workItemTypeFilter = pathParams['filter[workitemtype]'];
     let workItemStateFilter = pathParams['filter[workitemstate]'];
     let iterationFilter = pathParams['filter[iteration]'];
+    let hasParentFilter = pathParams['filter[parentexists]'];
 
     console.log('Filtering on: '
       + (assigneeFilter ? 'assignee==' + assigneeFilter + ' ' : '')
       + (workItemTypeFilter ? 'workitemtype==' + workItemTypeFilter + ' ' : '')
       + (workItemStateFilter ? 'state==' + workItemStateFilter + ' ' : '')
       + (iterationFilter ? 'iteration==' + iterationFilter + ' ' : '')
+      + (hasParentFilter ? 'parentexists==' + hasParentFilter + ' ' : '')
     );
 
     var filteredWorkitems = new Array();
@@ -118,6 +120,18 @@ export class MockDataService {
         filterMatches = filterMatches && (this.workItems[i].attributes['system.state'] === workItemStateFilter);
       if (iterationFilter)
         filterMatches = filterMatches && this.workItems[i].relationships.iteration.data && (this.workItems[i].relationships.iteration.data.id === iterationFilter);
+      if (hasParentFilter && hasParentFilter=='false') {
+        // this is very dirty and relies on the mock data being of a certain form.
+        // this should be replaced by a proper link behaviour of parent-childs (see links in this class).
+        let hasParent = false;
+        if (['id5','id6','id7','id8','id9','id10'].indexOf(this.workItems[i].id)!=-1) {
+          console.log('WorkItem ' + this.workItems[i].id + ' has a parent.');
+          hasParent = true;
+        } else {
+          console.log('WorkItem ' + this.workItems[i].id + ' has no parent.');          
+        }
+        filterMatches = filterMatches && !hasParent;
+      }
 
       if (filterMatches)
         filteredWorkitems.push(this.makeCopy(this.workItems[i]));

--- a/src/app/shared/mock-data/schema-mock-generator.ts
+++ b/src/app/shared/mock-data/schema-mock-generator.ts
@@ -70,7 +70,7 @@ export class SchemaMockGenerator {
               }
             },
             'type': 'workitemlinktypes'
-            }
+          }
         ],
         'included': [
           {

--- a/src/app/shared/mock-http.ts
+++ b/src/app/shared/mock-http.ts
@@ -197,7 +197,7 @@ export class MockHttp extends HttpService {
         case '/workitems':
           if (path.extraPath) {
             return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemOrEntity(path.extraPath) );
-          } else if (path.params['filter[assignee]'] || path.params['filter[workitemtype]'] || path.params['filter[workitemstate]'] || path.params['filter[iteration]']) {
+          } else if (path.params['filter[assignee]'] || path.params['filter[workitemtype]'] || path.params['filter[workitemstate]'] || path.params['filter[iteration]'] || path.params['filter[parentexists]']) {
             this.logger.log('Request contains filter expressions: ' + JSON.stringify(path.params));
             return this.createResponse(url.toString(), 200, 'ok', this.createPage(this.mockDataService.getWorkItemsFiltered(path.params), path.params) );
           } else {

--- a/src/app/toolbar-panel/toolbar-panel.component.html
+++ b/src/app/toolbar-panel/toolbar-panel.component.html
@@ -29,6 +29,29 @@
             </li>
           </ul>
         </div>
+        <div *ngIf="context!=='boardview'" dropdown class="list-type-dropdown">
+          <button dropdownToggle
+              id="wi-list-type"
+              type="button"
+              class="btn btn-default">
+            <span class='dropdown-text'>
+              {{currentListType}}
+            </span>
+            <span class="caret"></span>
+          </button>
+          <ul id="wi-list-type-dropdown" class="dropdown-menu dropdown-ul" role="menu" dropdownMenu>
+            <li class="dropdown-li" (click)="onChangeListType('Hierarchy')">
+              <a>
+                <span class='dropdown-text'>Hierarchy</span>
+              </a>
+            </li>
+            <li class="dropdown-li" (click)="onChangeListType('Flat')">
+              <a>
+                <span class='dropdown-text'>Flat</span>
+              </a>
+            </li>
+          </ul>
+        </div>
         <!--
         <span *ngIf="context==='listview'" class="dropdown primary-action" dropdown>
           <button class="btn btn-default" id="wi_filter_dropdown" type="button" dropdownToggle>

--- a/src/app/toolbar-panel/toolbar-panel.component.ts
+++ b/src/app/toolbar-panel/toolbar-panel.component.ts
@@ -75,6 +75,7 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, 
     'assignee',
     'area'
   ];
+  currentListType: string = 'Hierarchy';
 
   private queryParamSubscriber = null;
   private savedFIlterFieldQueries = {};
@@ -89,7 +90,6 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, 
           value: null,
           separator: true
       };
-
 
   constructor(
     private router: Router,
@@ -148,6 +148,15 @@ export class ToolbarPanelComponent implements OnInit, AfterViewInit, OnChanges, 
     this.eventListeners.map((e) => e.unsubscribe());
     this.filterConfig.appliedFilters = [];
     this.filterService.clearFilters(this.allowedFilterKeys);
+  }
+
+  onChangeListType(type: string) {
+    this.currentListType = type;
+    if (type==='Hierarchy') {
+      this.broadcaster.broadcast('switched_show_wi_hierarchy_mode');
+    } else {
+      this.broadcaster.broadcast('switched_show_wi_flat_mode');
+    }
   }
 
   setFilterTypes(filters: FilterModel[]) {

--- a/src/app/work-item/work-item-list/work-item-list.component.html
+++ b/src/app/work-item/work-item-list/work-item-list.component.html
@@ -38,7 +38,8 @@
                 <alm-tree-list-item #treeListItem
                     [index]="index"
                     [node]="node"
-                    [template]="treeListItemTemplate">
+                    [template]="treeListItemTemplate"
+                    [class.expanderdisabled]="!showHierarchyList">
                   <template #treeListItemTemplate>
                     <alm-work-item-list-entry
                         id="{{'workItemList_OuterWrap_' + index}}"

--- a/src/app/work-item/work-item-list/work-item-list.component.scss
+++ b/src/app/work-item/work-item-list/work-item-list.component.scss
@@ -13,6 +13,12 @@
   }
 }
 
+.expanderdisabled {
+    .toggle-children {
+        display: none !important;
+    }
+}
+
 .tree-list-item {
   display: flex;
   align-items: inherit;

--- a/src/app/work-item/work-item-list/work-item-list.component.ts
+++ b/src/app/work-item/work-item-list/work-item-list.component.ts
@@ -217,6 +217,8 @@ export class WorkItemListComponent implements OnInit, AfterViewInit, DoCheck, On
         Observable.of(items[2]),
         this.workItemService.getWorkItems(
           this.pageSize,
+          // TODO: HERE WE NEED TO APPEND THE PARENT==NONE FILTER IF SWITCH IN ON
+          // /spaces/{id}/workitems?filter[parentexists]=false
           this.filterService.getAppliedFilters()
         )
       )


### PR DESCRIPTION
The tree now displays a "proper" tree without obvious dupes. Also added a toggle that enables switching between the tree and a flat list. 

KNOWN ISSUE: if the tree is expanded when switching the mode, the user will experience some weird issues. Problem is there seems to be no way of force-collapsing the tree yet. We will fix that in a later PR.
