### PR TITLE
chore(planner): remove traces of "almighty" string and replace them with "planner"

### DIFF
--- a/runtime/src/app/components/header/header.component.ts
+++ b/runtime/src/app/components/header/header.component.ts
@@ -19,7 +19,7 @@ import { Space, Spaces, SpaceService } from 'ngx-fabric8-wit';
 })
 
 export class HeaderComponent implements OnInit {
-  title = 'Almighty';
+  title = 'Planner';
   loggedInUser: User;
   loggedIn: Boolean = false;
   imgLoaded: Boolean = false;

--- a/runtime/src/index.html
+++ b/runtime/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <base href="/">
     <!--<script>document.write('<base href="' + document.location + '" />');</script>-->
-    <title>ALMighty</title>
+    <title>Planner</title>
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport">
   </head>

--- a/runtime/src/tests/work-item/work-item-list/EXCLUDED/basicAssignFilter.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/EXCLUDED/basicAssignFilter.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/EXCLUDED/basicDragAndDrop.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/EXCLUDED/basicDragAndDrop.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/EXCLUDED/orderOfExecution.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/EXCLUDED/orderOfExecution.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/EXCLUDED/unauthorizeduser.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/EXCLUDED/unauthorizeduser.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/296
  *

--- a/runtime/src/tests/work-item/work-item-list/EXCLUDED/work-item-timeStamp.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/EXCLUDED/work-item-timeStamp.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/assign.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/assign.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/298
  *

--- a/runtime/src/tests/work-item/work-item-list/constants.js
+++ b/runtime/src/tests/work-item/work-item-list/constants.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/displayAndUpdateWorkItemDetails.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/298
  *

--- a/runtime/src/tests/work-item/work-item-list/displayWorkItemList.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/displayWorkItemList.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display work item list 
  *  https://github.com/almighty/almighty-core/issues/297
  *  

--- a/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/linkItem.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/298
  *

--- a/runtime/src/tests/work-item/work-item-list/page-objects/common.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/common.page.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/page-objects/template.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/template.page.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-board.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-board.page.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-detail.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-detail.page.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
+++ b/runtime/src/tests/work-item/work-item-list/page-objects/work-item-list.page.js
@@ -1,5 +1,5 @@
 /**
- * AlMighty page object example module for work item list page
+ * Planner page object example module for work item list page
  * See: http://martinfowler.com/bliki/PageObject.html,
  * https://www.thoughtworks.com/insights/blog/using-page-objects-overcome-protractors-shortcomings
  * @author ldimaggi@redhat.com

--- a/runtime/src/tests/work-item/work-item-list/quickadd-workitem.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/quickadd-workitem.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/296
  *

--- a/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/smokeTest.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/298
  *

--- a/runtime/src/tests/work-item/work-item-list/startcoding.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/startcoding.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/298
  *

--- a/runtime/src/tests/work-item/work-item-list/test-template.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/test-template.spec.js
@@ -1,5 +1,5 @@
 /**
- * Template for automated UI tests for ALMighty
+ * Template for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/testHelpers.js
+++ b/runtime/src/tests/work-item/work-item-list/testHelpers.js
@@ -1,5 +1,5 @@
 /**
- * Support module for automated UI tests for ALMighty
+ * Support module for automated UI tests for Planner
  * 
  * Ref: https://www.sitepoint.com/understanding-module-exports-exports-node-js/
  * 

--- a/runtime/src/tests/work-item/work-item-list/testSupport.js
+++ b/runtime/src/tests/work-item/work-item-list/testSupport.js
@@ -1,5 +1,5 @@
 /**
- * Support module for automated UI tests for ALMighty
+ * Support module for automated UI tests for Planner
  * 
  * Ref: https://www.sitepoint.com/understanding-module-exports-exports-node-js/
  * 

--- a/runtime/src/tests/work-item/work-item-list/work-item-detailed-dialog.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/work-item-detailed-dialog.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/work-item-dynamic-fields.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/work-item-dynamic-fields.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/work-item-list.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/work-item-list.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  
  * Note on screen resolutions - See: http://www.itunesextractor.com/iphone-ipad-resolution.html
  * Tests will be run on these resolutions:

--- a/runtime/src/tests/work-item/work-item-list/workitem-naughty-string.spec.js
+++ b/runtime/src/tests/work-item/work-item-list/workitem-naughty-string.spec.js
@@ -1,5 +1,5 @@
 /**
- * POC test for automated UI tests for ALMighty
+ * POC test for automated UI tests for Planner
  *  Story: Display and Update Work Item Details
  *  https://github.com/almighty/almighty-core/issues/296
  *

--- a/runtime/tests/local_run_functional_tests.sh
+++ b/runtime/tests/local_run_functional_tests.sh
@@ -23,7 +23,7 @@ fi
 echo done.
 
 # Start the web app
-echo -n Starting Almighty development server...
+echo -n Starting Planner development server...
 (node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 >>$LOGFILE 2>&1 &)
 # Wait for port 8088 to be listening connections
 if [ $OS = 'Darwin' ]

--- a/runtime/tests/run_functional_tests.sh
+++ b/runtime/tests/run_functional_tests.sh
@@ -14,7 +14,7 @@ while ! (ncat -w 1 127.0.0.1 4444 </dev/null >/dev/null 2>&1); do sleep 1; done
 echo done.
 
 # Start the web app
-echo -n Starting Almighty development server...
+echo -n Starting Planner development server...
 (node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --progress --host 0.0.0.0 --port 8088 >>$LOGFILE 2>&1 &)
 # Wait for port 8088 to be listening connections
 while ! (ncat -w 1 127.0.0.1 8088 </dev/null >/dev/null 2>&1); do sleep 1; done


### PR DESCRIPTION
closes #1891 

## also, remove the `stats.json` file
That was lingering for quite a while, without any apparent purpose or use.