### PR TITLE
Run planner.on.mac os

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,9 @@ To quickly run the provided minimal Runtime with the Planner, simply run
 
  $ scripts/run-planner.sh --standalone
 
+> NOTE: To run the script on macOS, you will need to have `gnu-getopt` installed, run `brew install gnu-getopt`, and set it in your PATH
+ `echo 'export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"' >> ~/.zshrc`
+
 This will run the Planner using the minimal Runtime and a mock database. The service 
 will be available on *`localhost:8080`*
 


### PR DESCRIPTION
@michaelkleinhenz As discussed here: https://stackoverflow.com/questions/402377/using-getopts-in-bash-shell-script-to-get-long-and-short-command-line-options search for "# NOTE: This requires GNU getopt.  On Mac OS X and FreeBSD, you have to install this
# separately; see below."

I've added it as a pre-requisites for macOS