### PR TITLE
Revert "fix(frontend): show work item type name in list"

### DIFF
--- a/src/app/components/work-item-list-entry/work-item-list-entry.component.html
+++ b/src/app/components/work-item-list-entry/work-item-list-entry.component.html
@@ -14,7 +14,6 @@
     <div class="list-view-pf-left type workItemList_workItemType">
       <span almIcon [iconType]="workItem.attributes['system.state']" class="color-grey pull-left"></span>
       <span class="color-grey pull-left fa {{workItem.relationships?.baseType?.data?.attributes?.icon}}"></span>
-      <span class="pull-left">{{workItem.relationships?.baseType?.data?.attributes?.name}}"></span>
       <span class="pull-left"> {{workItem.id}} </span>
     </div>
     <div class="list-view-pf-body">


### PR DESCRIPTION
This reverts commit 8cd9115b50dbd2e3e019e2ecdd0845cf0b1a852d.

Sorry, I've used the Github UI to create this wrong commit. Will never do it again!