### PR TITLE
Refactor link creation

### DIFF
--- a/src/app/components/work-item-link/work-item-link.component.ts
+++ b/src/app/components/work-item-link/work-item-link.component.ts
@@ -34,7 +34,6 @@ export class WorkItemLinkComponent implements OnInit, OnChanges, DoCheck, OnDest
   showLinkComponent: Boolean = false;
   showLinkView: Boolean = false;
   showLinkCreator: Boolean = true;
-  searchAllowedType: string = '';
   searchNotAllowedIds: string[] = [];
   prevWItem: WorkItem | null = null;
   selectedTab: string | null = null;
@@ -118,7 +117,6 @@ export class WorkItemLinkComponent implements OnInit, OnChanges, DoCheck, OnDest
     this.searchWorkItems = [];
     this.selectedWorkItemId = null;
     this.selectedLinkType = relation;
-    this.searchAllowedType = relation.wiType;
     this.setSearchNotAllowedIds();
   }
 
@@ -267,7 +265,7 @@ export class WorkItemLinkComponent implements OnInit, OnChanges, DoCheck, OnDest
       if (term.trim() != "") {
       // Search on atleast 3 char or numeric
         if (term.length >= 3 || !isNaN(term)) {
-          this.workItemService.searchLinkWorkItem(term, this.searchAllowedType)
+          this.workItemService.searchLinkWorkItem(term)
             .subscribe((searchData: WorkItem[]) => {
               this.searchWorkItems = searchData.filter((item) => {
                 return this.searchNotAllowedIds.indexOf(item.id) == -1;

--- a/src/app/mock/mock-data.service.ts
+++ b/src/app/mock/mock-data.service.ts
@@ -181,8 +181,6 @@ export class MockDataService {
     localWorkItem.id = this.createId();
     localWorkItem.links = {
           'self': 'http://mock.service/api/workitems/id' + localWorkItem.id,
-          'sourceLinkTypes': 'http://mock.service/api/source-link-types',
-          'targetLinkTypes': 'http://mock.service/api/target-link-types'
         };
     this.workItemComments['id' + localWorkItem.id] = {
       'data': [],

--- a/src/app/mock/mock-data/schema-mock-generator.ts
+++ b/src/app/mock/mock-data/schema-mock-generator.ts
@@ -69,15 +69,6 @@ export class SchemaMockGenerator {
               'name': 'system',
               'version': 38
             }
-          },
-          {
-            'id': 'wilt-cat-1',
-            'type': 'workitemlinkcategories',
-            'attributes': {
-              'description': 'The user category is reserved for link types that can to be manipulated by the user.',
-              'name': 'user',
-              'version': 38
-            }
           }
         ],
         'meta': {

--- a/src/app/mock/mock-data/schema-mock-generator.ts
+++ b/src/app/mock/mock-data/schema-mock-generator.ts
@@ -56,18 +56,6 @@ export class SchemaMockGenerator {
                   'type': 'workitemlinkcategories'
                 }
               },
-              'source_type': {
-                'data': {
-                  'id': 'planneritem',
-                  'type': 'workitemtypes'
-                }
-              },
-              'target_type': {
-                'data': {
-                  'id': 'planneritem',
-                  'type': 'workitemtypes'
-                }
-              }
             },
             'type': 'workitemlinktypes'
           }

--- a/src/app/mock/mock-data/work-item-mock-generator.ts
+++ b/src/app/mock/mock-data/work-item-mock-generator.ts
@@ -157,8 +157,6 @@ export class WorkItemMockGenerator {
         'id': 'id' + n,
         'links': {
           'self': 'http://mock.service/api/workitems/id' + n,
-          'sourceLinkTypes': 'http://mock.service/api/source-link-types',
-          'targetLinkTypes': 'http://mock.service/api/target-link-types'
         },
         'relationships': {
           'assignees': { },

--- a/src/app/mock/mock-http.ts
+++ b/src/app/mock/mock-http.ts
@@ -247,10 +247,6 @@ export class MockHttp extends HttpService {
           } else {
             return this.createResponse(url.toString(), 200, 'ok', { data: this.mockDataService.getAllAreas() });
           }
-        case '/source-link-types':
-          return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinkTypes() );
-        case '/target-link-types':
-          return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinkTypes() );
         default:
           console.log('######## URL Not found ########');
           console.log(url.toString());

--- a/src/app/mock/mock-http.ts
+++ b/src/app/mock/mock-http.ts
@@ -247,6 +247,8 @@ export class MockHttp extends HttpService {
           } else {
             return this.createResponse(url.toString(), 200, 'ok', { data: this.mockDataService.getAllAreas() });
           }
+        case '/workitemlinktypes':
+          return this.createResponse(url.toString(), 200, 'ok', this.mockDataService.getWorkItemLinkTypes());
         default:
           console.log('######## URL Not found ########');
           console.log(url.toString());

--- a/src/app/models/link-type.ts
+++ b/src/app/models/link-type.ts
@@ -8,24 +8,12 @@ export class LinkType {
     'forward_name': string,
     'name': string,
     'reverse_name': string,
-    'topology': string, 
+    'topology': string,
     'version': number
   };
   relationships: {
     // 'link_category': LinkCategory,
     'link_category': {
-      'data': {
-        'id': string,
-        'type': string
-      }
-    }
-    'source_type': {
-      'data': {
-        'id': string,
-        'type': string
-      }
-    },
-    'target_type': {
       'data': {
         'id': string,
         'type': string

--- a/src/app/models/work-item.ts
+++ b/src/app/models/work-item.ts
@@ -14,8 +14,6 @@ export class WorkItem {
   relationalData?: RelationalData;
   links?: {
     self: string;
-    sourceLinkTypes?: string;
-    targetLinkTypes?: string;
   };
 }
 

--- a/src/app/services/work-item.service.ts
+++ b/src/app/services/work-item.service.ts
@@ -753,11 +753,11 @@ export class WorkItemService {
    * @return Promise of LinkType[]
    */
   getLinkTypes(workItem: WorkItem): Observable<Object> {
-    return Observable.forkJoin(this.getAllLinkTypes(workItem))
-        .map(items => {
+    return this.getAllLinkTypes(workItem)
+        .map(item => {
           let linkTypes: Object = {};
-          linkTypes['forwardLinks'] = items[0].json().data;
-          linkTypes['backwardLinks'] = items[1].json().data;
+          linkTypes['forwardLinks'] = item.json().data;
+          linkTypes['backwardLinks'] = item.json().data;
           return linkTypes;
         })
         .map((linkTypes: any) => { return this.formatLinkTypes(linkTypes); })

--- a/src/app/services/work-item.service.ts
+++ b/src/app/services/work-item.service.ts
@@ -938,12 +938,12 @@ export class WorkItemService {
     }
   }
 
-  searchLinkWorkItem(term: string, workItemType: string): Observable<WorkItem[]> {
+  searchLinkWorkItem(term: string): Observable<WorkItem[]> {
     if (this._currentSpace) {
       // FIXME: make the URL great again (when we know the right API URL for this)!
       // search within selected space
-      let searchUrl = this.baseApiUrl + 'search?spaceID=' + this._currentSpace.id + '&q=' + term + ' type:' + workItemType;
-      //let searchUrl = currentSpace.links.self + 'search?q=' + term + ' type:' + workItemType;
+      let searchUrl = this.baseApiUrl + 'search?spaceID=' + this._currentSpace.id + '&q=' + term;
+      //let searchUrl = currentSpace.links.self + 'search?q=' + term;
       return this.http
           .get(searchUrl)
           .map((response) => response.json().data as WorkItem[])

--- a/src/app/services/work-item.service.ts
+++ b/src/app/services/work-item.service.ts
@@ -731,18 +731,17 @@ export class WorkItemService {
       });
   }
 
-  getForwardLinkTypes(workItem: WorkItem): Observable<any> {
-    return this.http.get(workItem.links.targetLinkTypes)
+  /**
+   * Usage: This function fetches all the work item link types
+   * Store it in an instance variable
+   *
+   * @return Promise of LinkType[]
+   */
+  getAllLinkTypes(workItem: WorkItem): Observable<any> {
+    let workItemLinkTypesUrl = this._currentSpace.links.self + '/workitemlinktypes';
+    return this.http.get(workItemLinkTypesUrl)
       .catch((error: Error | any) => {
         this.notifyError('Getting link meta info failed (forward).', error);
-        return Observable.throw(new Error(error.message));
-      });
-  }
-
-  getBackwardLinkTypes(workItem: WorkItem): Observable<any> {
-    return this.http.get(workItem.links.sourceLinkTypes)
-      .catch((error: Error | any) => {
-        this.notifyError('Getting link meta info failed (backward).', error);
         return Observable.throw(new Error(error.message));
       });
   }
@@ -754,23 +753,18 @@ export class WorkItemService {
    * @return Promise of LinkType[]
    */
   getLinkTypes(workItem: WorkItem): Observable<Object> {
-    return Observable.forkJoin(
-      this.getForwardLinkTypes(workItem),
-      this.getBackwardLinkTypes(workItem)
-    )
-    .map(items => {
-      let linkTypes: Object = {};
-      linkTypes['forwardLinks'] = items[0].json().data;
-      linkTypes['backwardLinks'] = items[1].json().data;
-      return linkTypes;
-    })
-    .map((linkTypes: any) => {
-      return this.formatLinkTypes(linkTypes);
-    })
-    .catch((err) => {
-      console.log(err);
-      return Observable.of({});
-    });
+    return Observable.forkJoin(this.getAllLinkTypes(workItem))
+        .map(items => {
+          let linkTypes: Object = {};
+          linkTypes['forwardLinks'] = items[0].json().data;
+          linkTypes['backwardLinks'] = items[1].json().data;
+          return linkTypes;
+        })
+        .map((linkTypes: any) => { return this.formatLinkTypes(linkTypes); })
+        .catch((err) => {
+          console.log(err);
+          return Observable.of({});
+        });
   }
 
   formatLinkTypes(linkTypes: any): any {
@@ -779,16 +773,14 @@ export class WorkItemService {
       opLinkTypes.push({
         name: linkType.attributes['forward_name'],
         linkId: linkType.id,
-        linkType: 'forward',
-        wiType: linkType.relationships.target_type.data.id
+        linkType: 'forward'
       });
     });
     linkTypes.backwardLinks.forEach((linkType: LinkType) => {
       opLinkTypes.push({
         name: linkType.attributes['reverse_name'],
         linkId: linkType.id,
-        linkType: 'reverse',
-        wiType: linkType.relationships.source_type.data.id
+        linkType: 'reverse'
       });
     });
     return opLinkTypes;


### PR DESCRIPTION
Once https://github.com/almighty/almighty-core/pull/1444 is merged, we need to adopt the UI as well.

This is my attempt to do so but I haven't tested it, just went over the code and did the follwing:

1. Remove the source and target type fields from the work item link type
2. Don't filter by type when searching doing the type-ahead.

I would love to get some feedback on this because most of what I did was assisted guessing ;)