### PR TITLE
fix(table-config): Set arrows as disabled when no column is selected

### DIFF
--- a/src/app/components_ngrx/table-config/table-config.component.html
+++ b/src/app/components_ngrx/table-config/table-config.component.html
@@ -27,14 +27,24 @@
           </ul>
         </aside>
         <aside>
-          <span class="db fa fa-angle-right"
-            tooltip="Move to Displayed Attributes"
-            (click)="moveToDisplay()">
-          </span>
-          <span class="db fa fa-angle-left"
-            tooltip="Move to Available Attributes"
-            (click)="moveToAvailable()">
-          </span>
+          <span *ngIf="isNoAttributeSelected; else moveAttributes">
+            <span class="db fa fa-angle-right"
+              tooltip="Please select an attribute">
+            </span>
+            <span class="db fa fa-angle-left"
+              tooltip="Please select an attribute">
+            </span>              
+          </span>          
+          <ng-template #moveAttributes>
+            <span class="db fa fa-angle-right"
+              tooltip="Move to Displayed Attributes"
+              (click)="moveToDisplay()">
+            </span>
+            <span class="db fa fa-angle-left"
+              tooltip="Move to Available Attributes"
+              (click)="moveToAvailable()">
+            </span>
+          </ng-template>
         </aside>
         <aside>
           <small>Available Attributes</small>

--- a/src/app/components_ngrx/table-config/table-config.component.html
+++ b/src/app/components_ngrx/table-config/table-config.component.html
@@ -28,10 +28,10 @@
         </aside>
         <aside>
           <span *ngIf="isNoAttributeSelected; else moveAttributes">
-            <span class="db fa fa-angle-right"
+            <span class="db fa fa-angle-right arrow-disabled"
               tooltip="Please select an attribute">
             </span>
-            <span class="db fa fa-angle-left"
+            <span class="db fa fa-angle-left arrow-disabled"
               tooltip="Please select an attribute">
             </span>              
           </span>          

--- a/src/app/components_ngrx/table-config/table-config.component.less
+++ b/src/app/components_ngrx/table-config/table-config.component.less
@@ -54,5 +54,6 @@
     .fa {
       font-size: 16px;
     }
+    .arrow-disabled { color: grey; }
   }
 }

--- a/src/app/components_ngrx/table-config/table-config.component.ts
+++ b/src/app/components_ngrx/table-config/table-config.component.ts
@@ -17,6 +17,7 @@ export class TableConfigComponent {
   @Input() columns;
   @Output() readonly onMovetoAvailable: EventEmitter<any[]> = new EventEmitter();
   @Output() readonly onMovetoDisplay: EventEmitter<any[]> = new EventEmitter();
+  isNoAttributeSelected: Boolean = true;
 
   private isTableConfigOpen;
 
@@ -30,6 +31,15 @@ export class TableConfigComponent {
       col.selected = true;
     } else {
       col.selected = false;
+    }
+    this.checkIfNoColumnSelected();
+  }
+
+  checkIfNoColumnSelected() {
+    if (this.columns.filter(col => col.selected).length < 1) {
+      this.isNoAttributeSelected = true;
+    } else {
+      this.isNoAttributeSelected = false;
     }
   }
 

--- a/src/app/components_ngrx/table-config/table-config.spec.ts
+++ b/src/app/components_ngrx/table-config/table-config.spec.ts
@@ -1,0 +1,18 @@
+import { TableConfigComponent } from './table-config.component';
+
+/**
+ * Default checks for inputs
+ */
+describe('TableConfigComponent :: ', () => {
+  const comp = new TableConfigComponent();
+  it('isNoAttributeSelected should be false when atleast one component is selected', () => {
+    comp.columns = [{selected : true}, {selected : false}, {selected : false}];
+    comp.checkIfNoColumnSelected();
+    expect(comp.isNoAttributeSelected).toBe(false);
+  });
+  it('isNoAttributeSelected should be true when no component is selected', () => {
+    comp.columns = [{selected : false}, {selected : false}, {selected : false}];
+    comp.checkIfNoColumnSelected();
+    expect(comp.isNoAttributeSelected).toBe(true);
+  });
+});


### PR DESCRIPTION
### Mandatory
 - [x] What does this PR do? 
     Sets arrows in attribute settings as disabled when no attribute is selected in table-config component. 
- [x] What issue/task does this PR references?
     This PR addresses the following settings issue 
      https://github.com/openshiftio/openshift.io/issues/3856
- [x] Are the tests Included?
      Yes, testcases have been included.
___
Please note: This PR will work properly after the tooltip is in place ( https://github.com/fabric8-ui/fabric8-planner/pull/2818 ).
